### PR TITLE
Fix flaky Windows WebSocket/HTTP test harness and increase timeout

### DIFF
--- a/tests/FIO.Http.Tests/Utils/Utilities.fs
+++ b/tests/FIO.Http.Tests/Utils/Utilities.fs
@@ -55,7 +55,7 @@ let runWithTimeout (runtime: FIORuntime) (effect: FIO<'A, exn>) =
     match
         fiber.Task()
         |> Async.AwaitTask
-        |> fun async -> Async.RunSynchronously(async, timeout = 10_000)
+        |> fun async -> Async.RunSynchronously(async, timeout = 30_000)
     with
     | Succeeded value -> value
     | Failed error -> failtest $"Effect failed: {error}"
@@ -86,37 +86,48 @@ let findAvailablePort () =
     listener.Stop()
     port
 
+let private startTestHttpApp (routes: Routes<exn>) (runtime: DefaultRuntime) =
+    let rec attempt remaining =
+        let port = findAvailablePort ()
+        let config = ServerConfig.create "127.0.0.1" port
+
+        let builder = Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder()
+        builder.Logging.ClearProviders() |> ignore
+
+        builder.WebHost.ConfigureKestrel(fun options ->
+            options.Listen(System.Net.IPAddress.Parse "127.0.0.1", port))
+            |> ignore
+
+        let app = builder.Build()
+
+        RunExtensions.Run(
+            app,
+            Microsoft.AspNetCore.Http.RequestDelegate(fun ctx ->
+                task {
+                    try
+                        do! KestrelBridge.handleRequest runtime routes config.MaxRequestBodySize ctx
+                    with ex ->
+                        let message =
+                            sprintf "%s\n%s" ex.Message (if isNull ex.StackTrace then "" else ex.StackTrace)
+                        ctx.Response.StatusCode <- 500
+                        let bytes = Encoding.UTF8.GetBytes message
+                        do! ctx.Response.Body.WriteAsync(bytes, 0, bytes.Length)
+                })
+        )
+
+        try
+            app.StartAsync().Wait()
+            port, app
+        with _ when remaining > 0 ->
+            (try app.DisposeAsync().AsTask().Wait() with _ -> ())
+            Thread.Sleep 50
+            attempt (remaining - 1)
+
+    attempt 10
+
 let withTestHttpServer (routes: Routes<exn>) (action: int -> unit) =
-    let port = findAvailablePort ()
-    let config = ServerConfig.create "127.0.0.1" port
     let runtime = new DefaultRuntime()
-
-    let builder = Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder()
-    builder.Logging.ClearProviders() |> ignore
-
-    builder.WebHost.ConfigureKestrel(fun options ->
-        options.Listen(System.Net.IPAddress.Parse "127.0.0.1", port))
-        |> ignore
-
-    let app = builder.Build()
-
-    RunExtensions.Run(
-        app,
-        Microsoft.AspNetCore.Http.RequestDelegate(fun ctx ->
-            task {
-                try
-                    do! KestrelBridge.handleRequest runtime routes config.MaxRequestBodySize ctx
-                with ex ->
-                    let message =
-                        sprintf "%s\n%s" ex.Message (if isNull ex.StackTrace then "" else ex.StackTrace)
-                    ctx.Response.StatusCode <- 500
-                    let bytes = Encoding.UTF8.GetBytes message
-                    do! ctx.Response.Body.WriteAsync(bytes, 0, bytes.Length)
-            })
-    )
-
-    let startTask = app.StartAsync()
-    startTask.Wait()
+    let port, app = startTestHttpApp routes runtime
 
     try
         Thread.Sleep 200

--- a/tests/FIO.WebSockets.Tests/Utils/Utilities.fs
+++ b/tests/FIO.WebSockets.Tests/Utils/Utilities.fs
@@ -96,19 +96,39 @@ let private runWithTimeout (runtime: FIORuntime) (effect: FIO<'A, WsError>) =
     match
         fiber.Task()
         |> Async.AwaitTask
-        |> fun async -> Async.RunSynchronously(async, timeout = 10_000)
+        |> fun async -> Async.RunSynchronously(async, timeout = 30_000)
     with
     | Succeeded value -> value
     | Failed error -> failtest $"Effect failed: {error}"
     | Interrupted ex -> failtest $"Interrupted: {ex.Message}"
 
-let withTestServer (handler: WebSocket -> FIO<unit, WsError>) (action: int -> FIO<'A, WsError>) (runtime: FIORuntime) =
-    let port = findAvailablePort ()
-    let url = $"http://localhost:{port}/"
+let private startTestListener () =
+    let rec attempt remaining =
+        fio {
+            let port = findAvailablePort ()
+            let url = $"http://localhost:{port}/"
 
+            let! outcome =
+                (WebSocketServer.start url)
+                    .Map(fun listener -> Ok(port, listener))
+                    .CatchAll(fun error -> FIO.succeed (Error error))
+
+            match outcome with
+            | Ok result -> return result
+            | Error error ->
+                if remaining > 0 then
+                    do! FIO.sleep (TimeSpan.FromMilliseconds 50.0) WsError.fromException
+                    return! attempt (remaining - 1)
+                else
+                    return! FIO.fail error
+        }
+
+    attempt 10
+
+let withTestServer (handler: WebSocket -> FIO<unit, WsError>) (action: int -> FIO<'A, WsError>) (runtime: FIORuntime) =
     let effect =
         fio {
-            let! listener = WebSocketServer.start url
+            let! port, listener = startTestListener ()
 
             let! serverFiber =
                 (fio {
@@ -126,9 +146,6 @@ let withTestServer (handler: WebSocket -> FIO<unit, WsError>) (action: int -> FI
     runWithTimeout runtime effect
 
 let withTestEchoServer (action: int -> FIO<'A, WsError>) (runtime: FIORuntime) =
-    let port = findAvailablePort ()
-    let url = $"http://localhost:{port}/"
-
     let closingEchoHandler (ws: WebSocket) =
         fio {
             do! echoHandler ws
@@ -137,7 +154,7 @@ let withTestEchoServer (action: int -> FIO<'A, WsError>) (runtime: FIORuntime) =
 
     let effect =
         fio {
-            let! listener = WebSocketServer.start url
+            let! port, listener = startTestListener ()
 
             let! serverFiber =
                 (WebSocketServer.acceptLoop listener WebSocketConfig.defaultConfig closingEchoHandler).Fork()


### PR DESCRIPTION
This pull request improves the reliability of test utilities for both HTTP and WebSocket servers by introducing retry logic when starting test servers and increasing timeouts for asynchronous operations. These changes help reduce test flakiness due to port conflicts or slow startup times.

**Test server startup reliability:**

* Added retry logic to HTTP test server setup by introducing a `startTestHttpApp` function that attempts to start the server up to 10 times if a port is unavailable, cleaning up resources between attempts (`tests/FIO.Http.Tests/Utils/Utilities.fs`). [[1]](diffhunk://#diff-60ff6c4959bedc8e3b2046e382209b5bbe76df1cd930982bfe76670319e9c766L89-L92) [[2]](diffhunk://#diff-60ff6c4959bedc8e3b2046e382209b5bbe76df1cd930982bfe76670319e9c766L118-R130)
* Added similar retry logic to WebSocket test server setup with a new `startTestListener` function, retrying up to 10 times with a short delay if the server fails to start (`tests/FIO.WebSockets.Tests/Utils/Utilities.fs`).

**Timeout improvements:**

* Increased the timeout for running asynchronous test effects from 10 seconds to 30 seconds in both HTTP and WebSocket test utilities to accommodate slower environments (`tests/FIO.Http.Tests/Utils/Utilities.fs`, `tests/FIO.WebSockets.Tests/Utils/Utilities.fs`). [[1]](diffhunk://#diff-60ff6c4959bedc8e3b2046e382209b5bbe76df1cd930982bfe76670319e9c766L58-R58) [[2]](diffhunk://#diff-7c824ba7a9562c72a37294ed079a936fed1993882e6b1df2308535d7fd94a219L99-R131)

**Code simplification and consistency:**

* Refactored test server setup functions to consistently use the new retry logic, removing duplicated port selection logic and streamlining the server startup process in both HTTP and WebSocket test helpers (`tests/FIO.Http.Tests/Utils/Utilities.fs`, `tests/FIO.WebSockets.Tests/Utils/Utilities.fs`). [[1]](diffhunk://#diff-7c824ba7a9562c72a37294ed079a936fed1993882e6b1df2308535d7fd94a219L129-L131) [[2]](diffhunk://#diff-7c824ba7a9562c72a37294ed079a936fed1993882e6b1df2308535d7fd94a219L140-R157)Retry HttpListener/Kestrel bind on a fresh ephemeral port to avoid the findAvailablePort port-reuse race (Windows HTTP.sys machine-wide URL registration conflicts), and raise the runWithTimeout safety-net cap from 10s to 30s for the slower Windows WebSocket path.

<!-- Thanks for contributing to FIO! Please fill out the sections below. -->

## Summary

<!-- What does this PR do, and why? -->

## Related issues

<!-- e.g. Closes #123 -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / internal change (no behavior change)
- [ ] Documentation
- [ ] Build / CI / tooling

## Checklist

- [x] `dotnet build` succeeds with no warnings (`WarningsAsErrors=true`)
- [x] `dotnet test` passes
- [x] Tests added/updated for behavior changes
- [x] Examples and docs updated where relevant
- [x] Package versions (if changed) go through `Directory.Packages.props`

## Notes for reviewers

<!-- Anything that needs special attention, trade-offs, or follow-ups. -->
