### PR TITLE
Add JoinFirst and JoinAllFailFast primitives with updated parallel combinators

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ dotnet run -c Release --project benchmarks/FIO.Benchmarks -- --list flat        
 
 `FIO<'A, 'E>` is a discriminated union representing lazy effects. DU cases are `internal` — external code uses factory functions and instance methods.
 
-Key DU cases: `Success`/`Failure` (terminal), `Interrupt` (self-interrupt), `Action` (sync side effects), `WriteChan`/`ReadChan` (channels), `ForkEffect` (forking), `JoinFiber` (waiting), `AwaitTask` (.NET Task interop), `ChainSuccess`/`ChainError`/`ChainBoth` (bind), `OnFinalize` (finalizer infrastructure), `FiberCancellationToken` (current fiber token), `Suspend` (deferred construction).
+Key DU cases: `Success`/`Failure` (terminal), `Interrupt` (self-interrupt), `Action` (sync side effects), `WriteChan`/`ReadChan` (channels), `ForkEffect` (forking), `JoinFiber` (waiting), `JoinFirst` (first of several fibers to settle), `JoinAllFailFast` (all fibers, settling early on first failure), `AwaitTask` (.NET Task interop), `ChainSuccess`/`ChainError`/`ChainBoth` (bind), `OnFinalize` (finalizer infrastructure), `FiberCancellationToken` (current fiber token), `Suspend` (deferred construction).
 
 ### Runtime Hierarchy
 
@@ -57,7 +57,7 @@ Console I/O (`src/FIO/Console.fs`):
 Runtime (`src/FIO/Runtime/`):
 - `Runtime.fs` — `FIORuntime` base, `WorkerConfig`, `ContStackPool`, `WorkItemPool`
 - `WorkerInfrastructure.fs` — `FIOWorkerRuntime`, `WorkerLifecycle`
-- `InterpreterCore.fs` — shared interpreter (`InterpreterState`, `processOutcome`/`processResult`/`handleSharedCase`, `Outcome` DU, `RuntimeCase` DU for runtime-specific dispatch)
+- `InterpreterCore.fs` — shared interpreter (`InterpreterState`, `processOutcome`/`processResult`/`handleSharedCase`, `Outcome` DU, `RuntimeCase` DU for runtime-specific dispatch, park helpers for the `JoinFirst`/`JoinAllFailFast` primitives)
 - `DirectRuntime.fs` / `PollingRuntime.fs` / `SignalingRuntime.fs` / `WorkStealingRuntime.fs` / `DefaultRuntime.fs` (alias for `WorkStealingRuntime`)
 
 Framework (`src/FIO/App.fs`): `FIOApp<'A,'E>` with 5-member surface (`effect`, `runtime`, `onShutdown`, `onShutdownTimeout`, `mapExitCode`) over `AppResult` (`AppSucceeded`/`AppFailed`/`AppInterrupted`/`AppFatalError`).
@@ -154,6 +154,7 @@ Two tiers — see [`docs/COMMENT_STYLE.md`](../docs/COMMENT_STYLE.md):
 - **Sequential ordering**: `>>=`, `<*>`, `*>`, `<*` preserve left-to-right semantics
 - **Parallel operators**: `<&>`, `&>`, `<&`, `<&&>` must be genuinely concurrent in fiber runtimes
 - **Interruption semantics**: interruption must propagate through fibers consistently across all runtimes
+- **Fail-fast parallelism**: the parallel combinators (`ZipPar`/`Race` family, `forEachPar`) settle on the first relevant completion and interrupt losers/peers — they must never hang on a stuck sibling
 - **Finalizer guarantee**: `Ensuring` finalizers run on all three outcomes — success, error, and interruption
 - **Error typing**: extensions must not leak raw exceptions as public errors
 
@@ -177,6 +178,7 @@ Two tiers — see [`docs/COMMENT_STYLE.md`](../docs/COMMENT_STYLE.md):
 ## Architecture Change Checklist
 
 - **New effect constructor**: update `Core.fs` (FIO DU + `UpcastResult`/`UpcastError`/`UpcastBoth`), `Factories.fs`, `Extensions.fs`, `Operators.fs`, and `CE.fs`
+- **New shared effect case**: add handling to `handleSharedCase` in `InterpreterCore.fs`; runtime-specific cases go in the `RuntimeCase` DU, routed from `handleSharedCase`, with arms in all four runtime interpreters
 - **New runtime DU case**: update `Core.fs` and all four runtime interpreters (`DirectRuntime.fs`, `PollingRuntime.fs`, `SignalingRuntime.fs`, `WorkStealingRuntime.fs`)
 - **Runtime change**: update interpreter logic, add tests, validate benchmarks
 - **Extension change**: update error model, DSL surface, and extension README

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,7 +94,7 @@ Framework (`src/FIO/App.fs`): `FIOApp<'A,'E>` with 7-member surface (`effect`, `
 | `*>` / `<*` | Sequential | Second / First | Side effect ordering |
 | `<&>` | Parallel | Tuple | Concurrent exec |
 | `&>` / `<&` | Parallel | Second / First | Concurrent, keep one |
-| `<&&>` | Parallel | Unit | Fire-and-forget parallel |
+| `<&&>` | Parallel | Unit | Parallel, discard both (awaits both, fail-fast) |
 | `<\|>` | Sequential | First success | Fallback/recovery |
 | `<+>` | Sequential | Choice | Either-fallback (OrElseEither) |
 | `<?>` | Parallel | Choice | Race for first completion (RaceEither) |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,6 +55,7 @@ jobs:
           FIO_BENCH_FIBONACCI_N: "20"
           FIO_BENCH_TRAPEZOIDAL_WORKERS: "2"
           FIO_BENCH_TRAPEZOIDAL_POINTS: "10000"
+          FIO_BENCH_ZIPRACE_ROUNDS: "50"
         # --job Dry runs a warmup + target invocation per case, so this also exercises
         # effect re-runnability; main returns non-zero if any benchmark throws or fails to run.
         run: dotnet run -c Release --project benchmarks/FIO.Benchmarks -- --filter "*" --job Dry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ FIO is a type-safe, purely functional effect system for F#. IO monad + fibers (g
 
 **Target:** .NET 10, F# 10, `.slnx` solution format (`FIO.slnx`). SDK pinned to `10.0.301` via `global.json` (`rollForward: latestMinor`).
 
-Repository: <https://github.com/fs-fio/fio> · License: MIT · Baseline version: `0.1.15-alpha` (single source of truth in `Directory.Build.props`).
+Repository: <https://github.com/fs-fio/fio> · License: MIT · Baseline version: `0.2.0-beta` (single source of truth in `Directory.Build.props`).
 
 ## Build Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Concurrency is built on the core types: **Fiber<'A,'E>** (green threads via `.Fo
 | `<&>` | Par | Tuple | Concurrent exec |
 | `&>` | Par | Second | Concurrent, keep second |
 | `<&` | Par | First | Concurrent, keep first |
-| `<&&>` | Par | Unit | Fire-and-forget parallel |
+| `<&&>` | Par | Unit | Parallel, discard both (awaits both, fail-fast) |
 | `<\|>` | Seq | First success | Fallback/recovery |
 | `<+>` | Seq | Choice | Either-fallback (OrElseEither) |
 | `<?>` | Par | Choice | Race for first completion (RaceEither) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,9 @@ documented in `benchmarks/FIO.Benchmarks/README.md`.
 Core DSL (`src/FIO/DSL/`), compile order matters:
 - `Utilities.fs` - Internal boxing/atomics helpers (`boxOnError`, `boxFunc`, `boxTask`, `boxVoidTask`; `tryClaim`, `tryTransition`, `transitionFrom`, `initIfNull`)
 - `Exceptions.fs` - `InterruptionCause` DU and `FiberInterruptedException`
-- `Core.fs` - `FIO<'A,'E>` DU, `Fiber<'A,'E>`, `Channel<'A>`, `FiberContext`, `WorkItem`, `ContStack`. Also hosts the type's primitive instance members: `FlatMap`, `CatchAll`, `Ensuring`, `Fork`, and the transformation cluster `Map` / `MapError` / `MapBoth` / `Result` / `Option` / `Choice` (derived purely from `Success`/`Failure` constructors + the four primitives).
+- `Core.fs` - `FIO<'A,'E>` DU, `Fiber<'A,'E>`, `Channel<'A>`, `FiberContext`, `WorkItem`, `ContStack`, `JoinAllLatch`. Also hosts the type's primitive instance members: `FlatMap`, `CatchAll`, `Ensuring`, `Fork`, and the transformation cluster `Map` / `MapError` / `MapBoth` / `Result` / `Option` / `Choice` (derived purely from `Success`/`Failure` constructors + the four primitives).
 - `Factories.fs` - `FIO.succeed`, `FIO.fail`, `FIO.attempt`, `FIO.suspend`, `FIO.sleep`, `FIO.collectAll`, `FIO.collectAllPar`, `FIO.forkTask`, etc.
-- `Extensions.fs` - Instance methods built on the Core cluster (`Zip`, `Tap`, `Race`, `RaceFirst`, `Retry`, `Timeout`, `OrElse`, etc.)
+- `Extensions.fs` - Instance methods built on the Core cluster (`Zip`, `Tap`, `Race`, `RaceFirst`, `Retry`, `Timeout`, `OrElse`, etc.). The parallel `ZipPar`/`Race` family is fail-fast — built on the internal `JoinFirst` primitive, losers are interrupted
 - `Operators.fs` - Infix operators (`>>=`, `<!>`, `<&>`, `<|>`, etc.), in an `[<AutoOpen>]` module
 - `CE.fs` - `fio { }` computation expression builder
 
@@ -75,7 +75,7 @@ Console I/O (`src/FIO/Console.fs`):
 Runtime (`src/FIO/Runtime/`):
 - `Runtime.fs` - `FIORuntime` (abstract base), `WorkerConfig`, `ContStackPool`, `WorkItemPool`
 - `WorkerInfrastructure.fs` - `FIOWorkerRuntime` (adds EvaluationWorkers/EvaluationSteps/BlockingWorkers params), `WorkerLifecycle`
-- `InterpreterCore.fs` - Shared interpreter logic (`InterpreterState` struct, `processOutcome`/`processResult`/`handleSharedCase`, `Outcome` DU, `RuntimeCase` DU for runtime-specific dispatch)
+- `InterpreterCore.fs` - Shared interpreter logic (`InterpreterState` struct, `processOutcome`/`processResult`/`handleSharedCase`, `Outcome` DU, `RuntimeCase` DU for runtime-specific dispatch, and the park helpers for the `JoinFirst`/`JoinAllFailFast` primitives)
 - `DirectRuntime.fs` - .NET Tasks, waits for blocked fibers
 - `PollingRuntime.fs` - Custom fibers, linear-time blocked handling
 - `SignalingRuntime.fs` - Custom fibers, event-driven blocked handling (dedicated `BlockingWorker` + signal queue; constant-time reschedule). A comparison/legacy runtime — superseded as the default by `WorkStealingRuntime`
@@ -98,6 +98,8 @@ Extension libs expose `[<RequireQualifiedAccess>]` modules named after their dom
 - `WriteChan`/`ReadChan` - Channel message passing
 - `ForkEffect` - Fork a fiber
 - `JoinFiber` - Wait for fiber
+- `JoinFirst` - Wait for the first of several fibers to settle
+- `JoinAllFailFast` - Wait for all fibers, settling early on the first failure
 - `AwaitTask` - .NET Task interop
 - `ChainSuccess`/`ChainError`/`ChainBoth` - Effect composition (bind)
 - `OnFinalize` - Interrupt-safe finalizer infrastructure
@@ -206,14 +208,14 @@ Library modules use **qualified access**: e.g. `Console.printLine "msg" id`.
 ## Benchmarks
 
 Macro benchmarks live in `benchmarks/FIO.Benchmarks/` (BenchmarkDotNet 0.15.8). Twelve workloads:
-**Bang, Big, BoundedBuffer, Chameneos, Counting, Fibonacci, Fork, Philosophers, Pingpong, Threadring, Trapezoidal, ZipRace**. Each is `[<MemoryDiagnoser>]` + `[<RankColumn>]`, sweeping its parameters × the configured runtimes, so every run reports **execution time and allocated memory**.
+**Bang, Big, BoundedBuffer, Chameneos, Counting, Fibonacci, Fork, Philosophers, Pingpong, Threadring, Trapezoidal, ZipRace**. Eleven are classic concurrency workloads; **ZipRace** is a combinator microbenchmark that regression-guards the parallel-combinator primitives. Each is `[<MemoryDiagnoser>]` + `[<RankColumn>]`, sweeping its parameters × the configured runtimes, so every run reports **execution time and allocated memory**.
 
 - **Runtimes:** spec format `Direct | Polling-{EWC}-{EWS}-{BWC} | Signaling-{EWC}-{EWS}-{BWC} | WorkStealing-{EWC}-{EWS}-{BWC}`. Set via `FIO_BENCH_RUNTIMES` (default `Direct,Polling-12-200-1,Signaling-12-200-1,WorkStealing-12-200-1`). Recommended `EWC = CPU cores − 2`.
 - **Iteration control:** `FIO_BENCH_WARMUP` (default 3), `FIO_BENCH_ITERATIONS` (default 30). A CLI `--job` (e.g. `--job Dry`, `--job Short`) **overrides** these env vars.
 - **Per-benchmark params:** `FIO_BENCH_<NAME>_<PARAM>` (e.g. `FIO_BENCH_PINGPONG_ROUNDS`, `FIO_BENCH_FORK_ACTORS`, `FIO_BENCH_BOUNDEDBUFFER_PRODUCERS`). Full table in `benchmarks/FIO.Benchmarks/README.md`.
 - **Output:** BenchmarkDotNet writes CSV/GitHub-markdown/HTML reports to `BenchmarkDotNet.Artifacts/results/` (git-ignored).
 - **Plotting (`benchmarks/plot.py`):** reads the `*-report.csv` files and writes per-benchmark + `summary` charts to `BenchmarkDotNet.Artifacts/plots/` as interactive HTML **and** static images (PNG/SVG, configurable via `--image-formats`; `pdf` also supported). Requires `pandas`, `plotly`, `kaleido`. `python benchmarks/plot.py --self-test` validates the parsers without touching artifacts.
-- **A/B comparison (`benchmarks/compare.py`, stdlib-only):** diffs two results directories and emits a markdown Δtime/Δalloc table with regression/win flags. Allocations are deterministic (comparable across sessions); **wall time drifts 20–50% between sessions** on dev machines — compare times only from same-session adjacent A/B runs, bracketed by sentinel re-runs (protocol: `docs/adr/0001-joinfirst-ab-regression-test.md`).
+- **A/B comparison (`benchmarks/compare.py`, stdlib-only):** diffs two results directories and emits a markdown Δtime/Δalloc table with regression/win flags. Allocations are deterministic (comparable across sessions); **wall time drifts 20–50% between sessions** on dev machines — compare times only from same-session adjacent A/B runs, bracketed by sentinel re-runs (full protocol in `benchmarks/FIO.Benchmarks/README.md`).
 
 `benchmarks/FIO.Benchmarks/README.md` is the source of truth (parameter defaults, tuning guidance, result interpretation, allocation/boxing notes).
 
@@ -239,6 +241,7 @@ Macro benchmarks live in `benchmarks/FIO.Benchmarks/` (BenchmarkDotNet 0.15.8). 
 - **Sequential ordering**: `>>=`, `<*>`, `*>`, `<*` preserve left-to-right semantics
 - **Parallel operators**: `<&>`, `&>`, `<&`, `<&&>` must be genuinely concurrent in fiber runtimes
 - **Interruption semantics**: interruption must propagate through fibers consistently across all runtimes
+- **Fail-fast parallelism**: the parallel combinators (`ZipPar`/`Race` family, `forEachPar`) settle on the first relevant completion and interrupt losers/peers — they must never hang on a stuck sibling
 - **Finalizer guarantee**: `Ensuring` finalizers run on all three outcomes — success, error, and interruption
 - **Error typing**: extensions must not leak raw exceptions as public errors
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ dotnet run -c Release --project benchmarks/FIO.Benchmarks -- --filter "*"       
 dotnet run -c Release --project benchmarks/FIO.Benchmarks -- --filter "*Pingpong*"  # one benchmark
 dotnet run -c Release --project benchmarks/FIO.Benchmarks -- --list flat            # list benchmarks
 python benchmarks/plot.py                       # visualize results (HTML + PNG/SVG)
+python benchmarks/compare.py <dirA> <dirB>      # A/B diff of two results dirs (stdlib-only)
 ```
 
 Formatting follows `.editorconfig` (4-space F#, LF, UTF-8); the build is warning-clean
@@ -204,14 +205,15 @@ Library modules use **qualified access**: e.g. `Console.printLine "msg" id`.
 
 ## Benchmarks
 
-Macro benchmarks live in `benchmarks/FIO.Benchmarks/` (BenchmarkDotNet 0.15.8). Eleven workloads:
-**Bang, Big, BoundedBuffer, Chameneos, Counting, Fibonacci, Fork, Philosophers, Pingpong, Threadring, Trapezoidal**. Each is `[<MemoryDiagnoser>]` + `[<RankColumn>]`, sweeping its parameters × the configured runtimes, so every run reports **execution time and allocated memory**.
+Macro benchmarks live in `benchmarks/FIO.Benchmarks/` (BenchmarkDotNet 0.15.8). Twelve workloads:
+**Bang, Big, BoundedBuffer, Chameneos, Counting, Fibonacci, Fork, Philosophers, Pingpong, Threadring, Trapezoidal, ZipRace**. Each is `[<MemoryDiagnoser>]` + `[<RankColumn>]`, sweeping its parameters × the configured runtimes, so every run reports **execution time and allocated memory**.
 
 - **Runtimes:** spec format `Direct | Polling-{EWC}-{EWS}-{BWC} | Signaling-{EWC}-{EWS}-{BWC} | WorkStealing-{EWC}-{EWS}-{BWC}`. Set via `FIO_BENCH_RUNTIMES` (default `Direct,Polling-12-200-1,Signaling-12-200-1,WorkStealing-12-200-1`). Recommended `EWC = CPU cores − 2`.
 - **Iteration control:** `FIO_BENCH_WARMUP` (default 3), `FIO_BENCH_ITERATIONS` (default 30). A CLI `--job` (e.g. `--job Dry`, `--job Short`) **overrides** these env vars.
 - **Per-benchmark params:** `FIO_BENCH_<NAME>_<PARAM>` (e.g. `FIO_BENCH_PINGPONG_ROUNDS`, `FIO_BENCH_FORK_ACTORS`, `FIO_BENCH_BOUNDEDBUFFER_PRODUCERS`). Full table in `benchmarks/FIO.Benchmarks/README.md`.
 - **Output:** BenchmarkDotNet writes CSV/GitHub-markdown/HTML reports to `BenchmarkDotNet.Artifacts/results/` (git-ignored).
 - **Plotting (`benchmarks/plot.py`):** reads the `*-report.csv` files and writes per-benchmark + `summary` charts to `BenchmarkDotNet.Artifacts/plots/` as interactive HTML **and** static images (PNG/SVG, configurable via `--image-formats`; `pdf` also supported). Requires `pandas`, `plotly`, `kaleido`. `python benchmarks/plot.py --self-test` validates the parsers without touching artifacts.
+- **A/B comparison (`benchmarks/compare.py`, stdlib-only):** diffs two results directories and emits a markdown Δtime/Δalloc table with regression/win flags. Allocations are deterministic (comparable across sessions); **wall time drifts 20–50% between sessions** on dev machines — compare times only from same-session adjacent A/B runs, bracketed by sentinel re-runs (protocol: `docs/adr/0001-joinfirst-ab-regression-test.md`).
 
 `benchmarks/FIO.Benchmarks/README.md` is the source of truth (parameter defaults, tuning guidance, result interpretation, allocation/boxing notes).
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
         the tag is the authoritative published version.
     -->
     <PropertyGroup>
-        <Version>0.1.15-alpha</Version>
+        <Version>0.2.0-beta</Version>
     </PropertyGroup>
 
     <!--

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ More in [examples/](examples/).
 - **Effects** — lazy, composable `FIO<'A, 'E>` with typed errors
 - **Fibers** — green threads for scalable concurrency
 - **Channels** — typed message passing between fibers
+- **Structured concurrency** — fail-fast `ZipPar`, `Race`, and `forEachPar` that interrupt losers automatically
 - **Composition** — `fio { }` CE, operators (`>>=`, `<&>`, `<|>`), combinators
 - **Modules** — `Console`
 

--- a/benchmarks/FIO.Benchmarks/Benchmarks/ZipRaceBenchmark.fs
+++ b/benchmarks/FIO.Benchmarks/Benchmarks/ZipRaceBenchmark.fs
@@ -1,0 +1,51 @@
+namespace FIO.Benchmarks.Benchmarks
+
+open FIO.DSL
+open FIO.Runtime
+open FIO.Benchmarks
+open FIO.Benchmarks.Effects
+
+open BenchmarkDotNet.Attributes
+
+open System
+
+// Measures the per-invocation cost of the parallel combinators (ZipPar + RaceFirst).
+[<MemoryDiagnoser>]
+[<RankColumn>]
+type ZipRaceBenchmark() =
+    let mutable runtime: FIORuntime = Unchecked.defaultof<_>
+    let mutable effect = Unchecked.defaultof<_>
+
+    // Round counts to sweep, overridable via FIO_BENCH_ZIPRACE_ROUNDS.
+    member _.RoundCounts =
+        RuntimeParam.intParams "FIO_BENCH_ZIPRACE_ROUNDS" [| 1_000; 10_000 |]
+
+    // Runtime specs to sweep, overridable via FIO_BENCH_RUNTIMES.
+    member _.Runtimes =
+        RuntimeParam.runtimes ()
+
+    // The round count for the current run.
+    [<ParamsSource("RoundCounts")>]
+    member val RoundCount = 0 with get, set
+
+    // The runtime spec for the current run.
+    [<ParamsSource("Runtimes")>]
+    member val Runtime = "" with get, set
+
+    // Builds the runtime and the workload effect for the current parameters.
+    [<GlobalSetup>]
+    member this.Setup () =
+        runtime <- RuntimeParam.create this.Runtime
+        effect <- ZipRace.effect this.RoundCount
+
+    // Disposes the runtime if it owns unmanaged resources.
+    [<GlobalCleanup>]
+    member _.Cleanup () =
+        match box runtime with
+        | :? IDisposable as d -> d.Dispose()
+        | _ -> ()
+
+    // Runs the workload effect to completion on the runtime under test.
+    [<Benchmark>]
+    member _.Run () =
+        RuntimeParam.run runtime effect

--- a/benchmarks/FIO.Benchmarks/Effects/ZipRace.fs
+++ b/benchmarks/FIO.Benchmarks/Effects/ZipRace.fs
@@ -1,0 +1,11 @@
+[<RequireQualifiedAccess>]
+module internal FIO.Benchmarks.Effects.ZipRace
+
+open FIO.DSL
+
+// Builds the ZipRace workload: sequential rounds of ZipPar and RaceFirst over trivial
+// effects, stressing the parallel combinators' per-invocation fork/settle/join cost.
+let effect roundCount : FIO<unit, exn> =
+    FIO.forEachDiscard (seq { 1..roundCount }) (fun round ->
+        ((FIO.succeed round).ZipPar(FIO.succeed (round + 1))).FlatMap <| fun _ ->
+            (FIO.succeed round).RaceFirst(FIO.succeed (round + 1)))

--- a/benchmarks/FIO.Benchmarks/FIO.Benchmarks.fsproj
+++ b/benchmarks/FIO.Benchmarks/FIO.Benchmarks.fsproj
@@ -18,6 +18,7 @@
         <Compile Include="Effects\Pingpong.fs" />
         <Compile Include="Effects\Threadring.fs" />
         <Compile Include="Effects\Trapezoidal.fs" />
+        <Compile Include="Effects\ZipRace.fs" />
         <Compile Include="Benchmarks\BangBenchmark.fs" />
         <Compile Include="Benchmarks\BigBenchmark.fs" />
         <Compile Include="Benchmarks\BoundedBufferBenchmark.fs" />
@@ -29,6 +30,7 @@
         <Compile Include="Benchmarks\PingpongBenchmark.fs" />
         <Compile Include="Benchmarks\ThreadringBenchmark.fs" />
         <Compile Include="Benchmarks\TrapezoidalBenchmark.fs" />
+        <Compile Include="Benchmarks\ZipRaceBenchmark.fs" />
         <Compile Include="Program.fs" />
     </ItemGroup>
 

--- a/benchmarks/FIO.Benchmarks/Program.fs
+++ b/benchmarks/FIO.Benchmarks/Program.fs
@@ -69,6 +69,7 @@ let main args =
                     typeof<PingpongBenchmark>
                     typeof<ThreadringBenchmark>
                     typeof<TrapezoidalBenchmark>
+                    typeof<ZipRaceBenchmark>
                 |]).Run(args, config)
 
     if summaries

--- a/benchmarks/FIO.Benchmarks/README.md
+++ b/benchmarks/FIO.Benchmarks/README.md
@@ -17,6 +17,15 @@ Macro benchmarks for the FIO effect system using [BenchmarkDotNet](https://bench
 | **Pingpong** | Message delivery overhead (2 actors) |
 | **Threadring** | Message passing + context switching (ring topology) |
 | **Trapezoidal** | CPU-bound master/worker map-reduce |
+| **ZipRace** | Parallel-combinator overhead (ZipPar + RaceFirst per round) |
+
+The suite contains two kinds of benchmark. The first eleven are **classic concurrency
+workloads** (largely from the actor-benchmark literature) that measure the scheduler and
+channel machinery under recognizable shapes. **ZipRace** is a **combinator microbenchmark**:
+it invokes the parallel combinators over trivial effects so that per-invocation primitive cost
+(fork, `JoinFirst` park/settle, loser interruption, join) dominates — it exists to
+regression-guard the parallel-combinator runtime primitives, and doubles as the CI hang canary
+for their park/wake protocol. Future primitive-level guards belong in this second category.
 
 ## Usage
 
@@ -40,7 +49,7 @@ dotnet run -c Release --project benchmarks/FIO.Benchmarks -- --filter "*Fork*" -
 dotnet run -c Release --project benchmarks/FIO.Benchmarks -- --filter "*Fork*" --exporters GitHub
 ```
 
-The default run (no `--filter`) executes all 11 benchmarks × all parameter combinations × 4 runtimes × 30 iterations. This produces a comprehensive performance profile across Direct, Polling, Signaling, and WorkStealing runtimes.
+The default run (no `--filter`) executes all 12 benchmarks × all parameter combinations × 4 runtimes × 30 iterations. This produces a comprehensive performance profile across Direct, Polling, Signaling, and WorkStealing runtimes.
 
 > Passing `--job` on the command line (e.g. `--job Dry` or `--job Short`) **overrides** the
 > env-var-configured job — only the CLI job runs. Omit `--job` to honor `FIO_BENCH_WARMUP` /
@@ -112,6 +121,7 @@ Runtime spec format: `Direct` | `Polling-{EWC}-{EWS}-{BWC}` | `Signaling-{EWC}-{
 | `FIO_BENCH_THREADRING_ROUNDS` | `1000,10000` | Threadring round counts |
 | `FIO_BENCH_TRAPEZOIDAL_WORKERS` | `8,16` | Trapezoidal worker count |
 | `FIO_BENCH_TRAPEZOIDAL_POINTS` | `1000000` | Trapezoidal total points |
+| `FIO_BENCH_ZIPRACE_ROUNDS` | `1000,10000` | ZipRace round counts |
 
 ### Full Example
 
@@ -174,3 +184,24 @@ images per output. Two outputs are produced:
   allocation-ratio heatmap vs `Direct`, and a per-runtime bar grid showing absolute mean times for every
   benchmark on a log axis. Uses the largest configured parameter set per benchmark, so comparisons
   reflect at-scale behaviour.
+
+## Comparing Two Runs (A/B)
+
+`benchmarks/compare.py` (stdlib-only — no pip installs needed) diffs two directories of
+`*-report.csv` files and emits a markdown table of Δtime/Δalloc per case, flagging regressions
+and wins:
+
+```bash
+python3 benchmarks/compare.py results/A results/B --label-a baseline --label-b candidate
+python3 benchmarks/compare.py results/A results/B --output comparison.md
+python3 benchmarks/compare.py --self-test
+```
+
+Directories are searched recursively; rows are matched on (method, params, runtime). Thresholds
+default to time ±10% / alloc ±5% (`--time-threshold` / `--alloc-threshold`).
+
+**Interpreting deltas:** allocated bytes are deterministic and comparable across sessions; wall
+time drifts with machine load/thermals (20–50% observed on an M4 Max across one day), so only
+compare times from runs taken back-to-back in the same session — ideally adjacent A/B pairs per
+benchmark, bracketed by re-runs of a fixed sentinel benchmark to measure the session noise floor.
+See `docs/adr/0001-joinfirst-ab-regression-test.md` for a worked example of the full protocol.

--- a/benchmarks/FIO.Benchmarks/README.md
+++ b/benchmarks/FIO.Benchmarks/README.md
@@ -204,4 +204,15 @@ default to time ±10% / alloc ±5% (`--time-threshold` / `--alloc-threshold`).
 time drifts with machine load/thermals (20–50% observed on an M4 Max across one day), so only
 compare times from runs taken back-to-back in the same session — ideally adjacent A/B pairs per
 benchmark, bracketed by re-runs of a fixed sentinel benchmark to measure the session noise floor.
-See `docs/adr/0001-joinfirst-ab-regression-test.md` for a worked example of the full protocol.
+
+**Full protocol for a working-tree-vs-baseline comparison:**
+
+1. Check out the baseline in a git worktree and copy the *current* benchmark project into it —
+   both sides must run byte-identical benchmark code; only the library may differ.
+2. Prebuild both trees in Release; run with a fixed `FIO_BENCH_WARMUP`/`FIO_BENCH_ITERATIONS`.
+3. For each benchmark, run baseline then candidate back-to-back and copy each `*-report.csv`
+   into `results/A` / `results/B`.
+4. Run a cheap fixed sentinel (e.g. Fork with `FIO_BENCH_FORK_ACTORS=1000`) on the baseline at
+   the start, one or two midpoints, and the end: its max/min spread per runtime is the session's
+   time-noise floor — time deltas below it are noise; allocation deltas are trustworthy regardless.
+5. Diff with `compare.py`. Run the machine idle and sleep-inhibited (`caffeinate -i` on macOS).

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Compare two directories of BenchmarkDotNet results (A/B) and emit a markdown delta report.
+
+Usage:
+    python benchmarks/compare.py <dir-a> <dir-b> [--label-a baseline] [--label-b candidate]
+                                 [--output report.md] [--time-threshold 10] [--alloc-threshold 5]
+
+Both directories are searched recursively for `*Benchmark-report.csv` files; benchmarks present
+in only one directory are skipped (with a note). Rows are matched on (Method, params, runtime).
+
+Unlike plot.py this script is stdlib-only (no pandas/plotly), so it runs without the plotting
+venv. Unit tables and column detection mirror plot.py — keep them in sync.
+
+Interpreting deltas: allocated bytes are deterministic and comparable across sessions; wall time
+drifts with machine conditions, so only compare times from runs taken in the same session
+(ideally adjacent, per benchmark). Negative Δ = improvement in B.
+"""
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+
+TIME_UNITS = {
+    "ns": 1e-9,
+    "us": 1e-6,
+    "μs": 1e-6,
+    "µs": 1e-6,
+    "ms": 1e-3,
+    "s": 1.0,
+    "m": 60.0,
+}
+BYTE_UNITS = {
+    "B": 1.0,
+    "KB": 1024.0,
+    "MB": 1024.0 ** 2,
+    "GB": 1024.0 ** 3,
+}
+RUNTIME_PATTERN = re.compile(r"^(Direct|Polling|Signaling|WorkStealing)(-\d+-\d+-\d+)?$")
+
+JOB_CHARACTERISTIC_COLS = {
+    "AnalyzeLaunchVariance", "EvaluateOverhead", "MaxAbsoluteError", "MaxRelativeError",
+    "MinInvokeCount", "MinIterationTime", "OutlierMode", "Affinity", "EnvironmentVariables",
+    "Jit", "LargeAddressAware", "Platform", "PowerPlanMode", "Runtime", "AllowVeryLargeObjects",
+    "Concurrent", "CpuGroups", "Force", "HeapAffinitizeMask", "HeapCount", "NoAffinitize",
+    "RetainVm", "Server", "Arguments", "BuildConfiguration", "Clock", "EngineFactory",
+    "NuGetReferences", "Toolchain", "IsMutator", "InvocationCount", "IterationCount",
+    "IterationTime", "LaunchCount", "MaxIterationCount", "MaxWarmupIterationCount",
+    "MemoryRandomization", "MinIterationCount", "MinWarmupIterationCount", "RunStrategy",
+    "UnrollFactor", "WarmupCount",
+}
+
+
+def parse_scalar(value: str, units: dict[str, float]) -> float:
+    parts = str(value).strip().split()
+    if len(parts) < 2 or parts[1] not in units:
+        return float("nan")
+    try:
+        return float(parts[0].replace(",", "")) * units[parts[1]]
+    except ValueError:
+        return float("nan")
+
+
+def extract_benchmark_name(filename: str) -> str:
+    match = re.search(r"\.(\w+?)Benchmark-report", filename)
+    return match.group(1) if match else filename
+
+
+def load_results(csv_path: Path) -> dict[tuple, dict]:
+    """Map (method, params..., runtime) -> {param_str, runtime, mean_str, mean, alloc_str, alloc}.
+
+    Parses positionally: the header contains *two* `Runtime` columns (the BenchmarkDotNet job
+    characteristic and the FIO runtime param), so name-keyed access loses one of them.
+    """
+    with open(csv_path, newline="", encoding="utf-8-sig") as f:
+        rows = list(csv.reader(f))
+    if len(rows) < 2:
+        return {}
+    header, data = rows[0], rows[1:]
+
+    # The FIO runtime param is the last column whose values all look like a runtime spec —
+    # distinguishing it by value from the job-characteristic Runtime column (".NET 10.0").
+    runtime_idx = next(
+        (i for i in reversed(range(len(header)))
+         if all(RUNTIME_PATTERN.match(r[i]) for r in data)),
+        None,
+    )
+    if runtime_idx is None:
+        raise ValueError(f"Could not find FIO runtime column in {csv_path}")
+
+    method_idx, mean_idx = header.index("Method"), header.index("Mean")
+    alloc_idx = header.index("Allocated") if "Allocated" in header else None
+    param_idxs = [
+        i for i in range(mean_idx)
+        if i != runtime_idx
+        and header[i] not in ("Method", "Job")
+        and header[i].split(".")[0] not in JOB_CHARACTERISTIC_COLS
+    ]
+
+    results = {}
+    for r in data:
+        key = (r[method_idx], *(r[i] for i in param_idxs), r[runtime_idx])
+        results[key] = {
+            "params": ", ".join(f"{header[i]}={r[i]}" for i in param_idxs) or r[method_idx],
+            "runtime": r[runtime_idx],
+            "mean_str": r[mean_idx],
+            "mean": parse_scalar(r[mean_idx], TIME_UNITS),
+            "alloc_str": r[alloc_idx] if alloc_idx is not None else "",
+            "alloc": parse_scalar(r[alloc_idx], BYTE_UNITS) if alloc_idx is not None else float("nan"),
+        }
+    return results
+
+
+def find_reports(directory: Path) -> dict[str, Path]:
+    return {extract_benchmark_name(p.name): p for p in sorted(directory.rglob("*Benchmark-report.csv"))}
+
+
+def delta(a: float, b: float) -> float:
+    return (b - a) / a * 100.0 if a == a and b == b and a != 0 else float("nan")
+
+
+def flag(pct: float, threshold: float) -> str:
+    if pct != pct:
+        return ""
+    if pct > threshold:
+        return " 🔴"
+    if pct < -threshold:
+        return " 🟢"
+    return ""
+
+
+def fmt_delta(pct: float) -> str:
+    return f"{pct:+.1f}%" if pct == pct else "n/a"
+
+
+def compare(dir_a: Path, dir_b: Path, label_a: str, label_b: str,
+            time_threshold: float, alloc_threshold: float) -> str:
+    reports_a, reports_b = find_reports(dir_a), find_reports(dir_b)
+    common = [n for n in reports_a if n in reports_b]
+    only_a = [n for n in reports_a if n not in reports_b]
+    only_b = [n for n in reports_b if n not in reports_a]
+
+    lines = [
+        f"# Benchmark comparison: {label_a} → {label_b}",
+        "",
+        f"Δ = ({label_b} − {label_a}) / {label_a}. Negative = improvement.",
+        f"Flags: time ±{time_threshold:.0f}%, alloc ±{alloc_threshold:.0f}% (🔴 regression / 🟢 win).",
+        "",
+    ]
+    time_regr = time_win = alloc_regr = alloc_win = compared = 0
+
+    for name in common:
+        a_rows, b_rows = load_results(reports_a[name]), load_results(reports_b[name])
+        keys = [k for k in a_rows if k in b_rows]
+        if not keys:
+            continue
+        lines += [f"## {name}", "",
+                  f"| Params | Runtime | Time {label_a} → {label_b} | Δtime | Alloc {label_a} → {label_b} | Δalloc |",
+                  "|---|---|---:|---:|---:|---:|"]
+        for k in keys:
+            a, b = a_rows[k], b_rows[k]
+            dt, da = delta(a["mean"], b["mean"]), delta(a["alloc"], b["alloc"])
+            compared += 1
+            time_regr += dt == dt and dt > time_threshold
+            time_win += dt == dt and dt < -time_threshold
+            alloc_regr += da == da and da > alloc_threshold
+            alloc_win += da == da and da < -alloc_threshold
+            lines.append(
+                f"| {a['params']} | {a['runtime']} "
+                f"| {a['mean_str']} → {b['mean_str']} | {fmt_delta(dt)}{flag(dt, time_threshold)} "
+                f"| {a['alloc_str']} → {b['alloc_str']} | {fmt_delta(da)}{flag(da, alloc_threshold)} |"
+            )
+        lines.append("")
+
+    summary = (f"**{compared} case(s) compared** — time: {time_regr} regression(s) / {time_win} win(s); "
+               f"alloc: {alloc_regr} regression(s) / {alloc_win} win(s).")
+    for skipped, where in ((only_a, label_a), (only_b, label_b)):
+        if skipped:
+            summary += f" Skipped (only in {where}): {', '.join(skipped)}."
+    lines.insert(4, summary)
+    return "\n".join(lines)
+
+
+def self_test() -> int:
+    assert parse_scalar("1,831.27 ms", TIME_UNITS) == 1831.27 * 1e-3
+    assert parse_scalar("241.0 μs", TIME_UNITS) == 241.0 * 1e-6
+    assert parse_scalar("3.41 GB", BYTE_UNITS) == 3.41 * 1024 ** 3
+    assert parse_scalar("NA", BYTE_UNITS) != parse_scalar("NA", BYTE_UNITS)  # NaN
+    assert extract_benchmark_name("FIO.Benchmarks.Benchmarks.ForkBenchmark-report.csv") == "Fork"
+    assert RUNTIME_PATTERN.match("WorkStealing-12-200-1")
+    assert RUNTIME_PATTERN.match("Direct")
+    assert not RUNTIME_PATTERN.match(".NET 10.0")
+    assert delta(100.0, 90.0) == -10.0
+    assert flag(11.0, 10.0) == " 🔴" and flag(-11.0, 10.0) == " 🟢" and flag(5.0, 10.0) == ""
+    print("self-test: OK")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("dir_a", nargs="?", type=Path, help="results directory A (baseline)")
+    parser.add_argument("dir_b", nargs="?", type=Path, help="results directory B (candidate)")
+    parser.add_argument("--label-a", default="A", help="display label for directory A")
+    parser.add_argument("--label-b", default="B", help="display label for directory B")
+    parser.add_argument("--output", type=Path, help="write markdown to this file instead of stdout")
+    parser.add_argument("--time-threshold", type=float, default=10.0, help="Δtime %% flag threshold")
+    parser.add_argument("--alloc-threshold", type=float, default=5.0, help="Δalloc %% flag threshold")
+    parser.add_argument("--self-test", action="store_true", help="validate parsers and exit")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.dir_a or not args.dir_b:
+        parser.error("dir_a and dir_b are required (or use --self-test)")
+    for d in (args.dir_a, args.dir_b):
+        if not d.is_dir():
+            parser.error(f"not a directory: {d}")
+
+    report = compare(args.dir_a, args.dir_b, args.label_a, args.label_b,
+                     args.time_threshold, args.alloc_threshold)
+    if args.output:
+        args.output.write_text(report + "\n", encoding="utf-8")
+        print(f"wrote {args.output}")
+    else:
+        print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/FIO/DSL/Core.fs
+++ b/src/FIO/DSL/Core.fs
@@ -142,6 +142,10 @@ and [<Sealed>] internal FiberContext() =
     member internal _.CancellationToken =
         cancelSource.Token
 
+    // Single-slot: installing replaces the previous observer, and the fire gate is consumed at
+    // most once per context. Install only when no live observer exists — either the slot is
+    // empty, or the previous observer's waiter was already claimed (how the join primitives
+    // re-park over surviving fibers).
     member internal this.SetOnTerminal (callback: unit -> unit) =
         onTerminalCallback <- ValueSome callback
         if this.IsTerminal() then

--- a/src/FIO/DSL/Core.fs
+++ b/src/FIO/DSL/Core.fs
@@ -142,10 +142,6 @@ and [<Sealed>] internal FiberContext() =
     member internal _.CancellationToken =
         cancelSource.Token
 
-    // Single-slot: installing replaces the previous observer, and the fire gate is consumed at
-    // most once per context. Install only when no live observer exists — either the slot is
-    // empty, or the previous observer's waiter was already claimed (how the join primitives
-    // re-park over surviving fibers).
     member internal this.SetOnTerminal (callback: unit -> unit) =
         onTerminalCallback <- ValueSome callback
         if this.IsTerminal() then

--- a/src/FIO/DSL/Core.fs
+++ b/src/FIO/DSL/Core.fs
@@ -193,8 +193,8 @@ and [<Sealed>] internal FiberContext() =
     member internal this.Complete value =
         if tryTransition &state (int FiberContextState.Running) (int FiberContextState.Completed) then
             this.DisposeRegistrations()
-            this.InvokeOnTerminal()
             resultSource.TrySetResult value |> ignore
+            this.InvokeOnTerminal()
 
     member internal this.CompleteAndReschedule (value, activeWorkItemQueue) =
         let oldState =
@@ -202,8 +202,8 @@ and [<Sealed>] internal FiberContext() =
         if oldState = int FiberContextState.Running ||
             oldState = int FiberContextState.Interrupted then
             this.DisposeRegistrations()
-            this.InvokeOnTerminal()
             resultSource.TrySetResult value |> ignore
+            this.InvokeOnTerminal()
 
             let queue = Volatile.Read &blockingWorkItemQueue
             if not (isNull queue) && queue.Count > 0 then
@@ -220,8 +220,8 @@ and [<Sealed>] internal FiberContext() =
             cancelSource.Cancel(throwOnFirstException = false)
             this.DisposeRegistrations()
             let interruptError = Error(FiberInterruptedException(id, cause, message) :> obj)
-            this.InvokeOnTerminal()
             resultSource.TrySetResult interruptError |> ignore
+            this.InvokeOnTerminal()
 
     member internal _.Cancel () =
         try
@@ -262,6 +262,32 @@ and [<Sealed>] internal FiberContext() =
         member this.Dispose () =
             this.Dispose true
             GC.SuppressFinalize this
+
+// Signals once when the first observed child fails (or is interrupted), or when the last child
+// succeeds. Only successes decrement, so the counter reaches zero iff every child succeeded —
+// a final "all done" signal can never race past an unclaimed failure.
+and [<Sealed>] internal JoinAllLatch(count: int, signal: unit -> unit) =
+
+    let mutable remaining = count
+
+    let mutable settled = 0
+
+    member _.OnChildTerminal (fiberContext: FiberContext) =
+
+        let mutable spinner = SpinWait()
+        while not fiberContext.Task.IsCompleted do
+            spinner.SpinOnce()
+
+        let failed =
+            match fiberContext.Task.Result with
+            | Error _ -> true
+            | Ok _ -> false
+
+        if failed then
+            if tryClaim &settled then
+                signal ()
+        elif Interlocked.Decrement &remaining = 0 && tryClaim &settled then
+            signal ()
 
 /// A running fiber (green thread) executing an effect. Join, await, interrupt, or poll it for its result.
 and [<Sealed>] Fiber<'A, 'E> internal () =
@@ -473,6 +499,8 @@ and FIO<'A, 'E> =
     | ReadChan of channel: Channel<'A>
     | ForkEffect of effect: FIO<obj, obj> * fiber: obj * fiberContext: FiberContext
     | JoinFiber of fiberContext: FiberContext
+    | JoinFirst of fiberContexts: FiberContext list
+    | JoinAllFailFast of fiberContexts: FiberContext[]
     | AwaitTask of task: Task<obj> * onError: (exn -> 'E)
     | ChainSuccess of effect: FIO<obj, 'E> * cont: (obj -> FIO<'A, 'E>)
     | ChainError of effect: FIO<'A, obj> * cont: (obj -> FIO<'A, 'E>)
@@ -635,6 +663,10 @@ and FIO<'A, 'E> =
             ForkEffect(effect, fiber, fiberContext)
         | JoinFiber fiberContext ->
             JoinFiber fiberContext
+        | JoinFirst fiberContexts ->
+            JoinFirst fiberContexts
+        | JoinAllFailFast fiberContexts ->
+            JoinAllFailFast fiberContexts
         | AwaitTask(task, onError) ->
             AwaitTask(task, onError)
         | ChainSuccess(effect, cont) ->
@@ -677,6 +709,10 @@ and FIO<'A, 'E> =
             ForkEffect(effect, fiber, fiberContext)
         | JoinFiber fiberContext ->
             JoinFiber fiberContext
+        | JoinFirst fiberContexts ->
+            JoinFirst fiberContexts
+        | JoinAllFailFast fiberContexts ->
+            JoinAllFailFast fiberContexts
         | AwaitTask(task, onError) ->
             AwaitTask(task, boxOnError onError)
         | ChainSuccess(effect, cont) ->
@@ -719,6 +755,10 @@ and FIO<'A, 'E> =
             ForkEffect(effect, fiber, fiberContext)
         | JoinFiber fiberContext ->
             JoinFiber fiberContext
+        | JoinFirst fiberContexts ->
+            JoinFirst fiberContexts
+        | JoinAllFailFast fiberContexts ->
+            JoinAllFailFast fiberContexts
         | AwaitTask(task, onError) ->
             AwaitTask(task, boxOnError onError)
         | ChainSuccess(effect, cont) ->

--- a/src/FIO/DSL/Extensions.fs
+++ b/src/FIO/DSL/Extensions.fs
@@ -237,20 +237,69 @@ module Extensions =
                 effect.Map <| fun _ ->
                     value
 
-        /// Returns an effect that runs this effect and the given effect concurrently, pairing their success values.
-        member inline this.ZipPar<'A1> (effect: FIO<'A1, 'E>) : FIO<'A * 'A1, 'E> =
-            effect.Fork().FlatMap <| fun fiber ->
-                this.FlatMap <| fun value ->
-                    fiber.Join().Map <| fun value' ->
-                        value, value'
+        /// Returns an effect that runs this effect and the given effect concurrently, pairing their success values, failing fast by interrupting the other side on the first failure. When both sides fail, the surfaced error is whichever settled first.
+        member this.ZipPar<'A1> (effect: FIO<'A1, 'E>) : FIO<'A * 'A1, 'E> =
+            FIO.suspend <| fun () ->
+                this.Fork().FlatMap <| fun fiber1 ->
+                    effect.Fork().FlatMap <| fun fiber2 ->
+                        let interruptBoth () =
+                            (fiber1.Interrupt ExplicitInterrupt "ZipPar sibling failed").Ignore()
+                                .FlatMap <| fun () ->
+                                    (fiber2.Interrupt ExplicitInterrupt "ZipPar sibling failed").Ignore()
 
-        /// Returns an effect that runs this effect and the given effect concurrently, pairing their errors.
-        member inline this.ZipParError (effect: FIO<'A, 'E>) : FIO<'A, 'E * 'E> =
-            effect.Fork().FlatMap(fun fiber ->
-                this.FlatMap(fun value ->
-                    fiber.Join().As value).CatchAll <| fun error ->
-                        fiber.Join().CatchAll <| fun error' ->
-                            FIO.fail (error, error'))
+                        (FIO.joinFirst [fiber1.Context; fiber2.Context]).FlatMap <| fun index ->
+                            if index = 0 then
+                                fiber1.Await().FlatMap <| fun result ->
+                                    match result with
+                                    | Succeeded value1 ->
+                                        fiber2.Join().Map <| fun value2 ->
+                                            value1, value2
+                                    | Failed error ->
+                                        (interruptBoth ()).FlatMap <| fun () -> FIO.fail error
+                                    | Interrupted ex ->
+                                        (interruptBoth ()).FlatMap <| fun () -> FIO.interrupt ex.cause ex.message
+                            else
+                                fiber2.Await().FlatMap <| fun result ->
+                                    match result with
+                                    | Succeeded value2 ->
+                                        fiber1.Join().Map <| fun value1 ->
+                                            value1, value2
+                                    | Failed error ->
+                                        (interruptBoth ()).FlatMap <| fun () -> FIO.fail error
+                                    | Interrupted ex ->
+                                        (interruptBoth ()).FlatMap <| fun () -> FIO.interrupt ex.cause ex.message
+
+        /// Returns an effect that runs this effect and the given effect concurrently, pairing their errors. Succeeds fast: the first side to succeed interrupts the other. The error pair is surfaced only if both fail; when both succeed, the surfaced value is whichever settled first (unspecified).
+        member this.ZipParError (effect: FIO<'A, 'E>) : FIO<'A, 'E * 'E> =
+            FIO.suspend <| fun () ->
+                this.Fork().FlatMap <| fun fiber1 ->
+                    effect.Fork().FlatMap <| fun fiber2 ->
+                        let interruptBoth () =
+                            (fiber1.Interrupt ExplicitInterrupt "ZipParError sibling succeeded").Ignore()
+                                .FlatMap <| fun () ->
+                                    (fiber2.Interrupt ExplicitInterrupt "ZipParError sibling succeeded").Ignore()
+
+                        (FIO.joinFirst [fiber1.Context; fiber2.Context]).FlatMap <| fun index ->
+                            let winner, loser = if index = 0 then fiber1, fiber2 else fiber2, fiber1
+                            winner.Await().FlatMap <| fun winnerResult ->
+                                match winnerResult with
+                                | Succeeded value ->
+                                    (interruptBoth ()).FlatMap <| fun () -> FIO.succeed value
+                                | Failed winnerError ->
+                                    loser.Await().FlatMap <| fun loserResult ->
+                                        match loserResult with
+                                        | Succeeded value ->
+                                            (interruptBoth ()).FlatMap <| fun () -> FIO.succeed value
+                                        | Failed loserError ->
+                                            let thisError, effectError =
+                                                if index = 0 then winnerError, loserError
+                                                else loserError, winnerError
+                                            FIO.fail (thisError, effectError)
+                                        | Interrupted ex ->
+                                            FIO.interrupt ex.cause ex.message
+                                | Interrupted ex ->
+                                    (interruptBoth ()).FlatMap <| fun () -> FIO.interrupt ex.cause ex.message
+
         /// Returns an effect that runs this effect and the given effect concurrently, keeping only the second value.
         member inline this.ZipParRight<'A1> (effect: FIO<'A1, 'E>) : FIO<'A1, 'E> =
             this.ZipPar(effect).Map snd
@@ -435,25 +484,13 @@ module Extensions =
         /// Returns an effect that runs this effect and the given effect concurrently, yielding the first to settle and interrupting the loser.
         member this.RaceFirst (effect: FIO<'A, 'E>) : FIO<'A, 'E> =
             FIO.suspend <| fun () ->
-                let channel = Channel<bool>()
-
-                let signal (won: bool) (fiber: Fiber<'A, 'E>) =
-                    fiber.Await().FlatMap <| fun result ->
-                        match result with
-                        | Succeeded _
-                        | Failed _ -> (channel.Write won).Unit()
-                        | Interrupted _ -> FIO.unit ()
-
                 this.Fork().FlatMap <| fun fiber1 ->
                     effect.Fork().FlatMap <| fun fiber2 ->
-                        (signal true fiber1).Fork().FlatMap <| fun _ ->
-                            (signal false fiber2).Fork().FlatMap <| fun _ ->
-                                channel.Read().FlatMap <| fun winnerIsFirst ->
-                                    let winner, loser =
-                                        if winnerIsFirst then fiber1, fiber2 else fiber2, fiber1
-                                    (loser.Interrupt ExplicitInterrupt "Lost race")
-                                        .Ignore()
-                                        .FlatMap <| fun () -> winner.Join()
+                        (FIO.joinFirst [fiber1.Context; fiber2.Context]).FlatMap <| fun index ->
+                            let winner, loser = if index = 0 then fiber1, fiber2 else fiber2, fiber1
+                            (loser.Interrupt ExplicitInterrupt "Lost race")
+                                .Ignore()
+                                .FlatMap <| fun () -> winner.Join()
 
         /// Returns an effect that races this effect against the given effect, yielding the winner as a Choice.
         member inline this.RaceEither<'A1> (effect: FIO<'A1, 'E>) : FIO<Choice<'A, 'A1>, 'E> =
@@ -462,28 +499,16 @@ module Extensions =
         /// Returns an effect that runs this effect and the given effect concurrently, yielding the first to succeed and interrupting the loser.
         member this.Race (effect: FIO<'A, 'E>) : FIO<'A, 'E> =
             FIO.suspend <| fun () ->
-                let channel = Channel<Result<'A * bool, 'E>>()
-
-                let signal (isFirst: bool) (fiber: Fiber<'A, 'E>) =
-                    fiber.Await().FlatMap <| fun result ->
-                        match result with
-                        | Succeeded value -> (channel.Write(Ok(value, isFirst))).Unit()
-                        | Failed error -> (channel.Write(Error error)).Unit()
-                        | Interrupted _ -> FIO.unit ()
-
                 this.Fork().FlatMap <| fun fiber1 ->
                     effect.Fork().FlatMap <| fun fiber2 ->
-                        (signal true fiber1).Fork().FlatMap <| fun _ ->
-                            (signal false fiber2).Fork().FlatMap <| fun _ ->
-                                channel.Read().FlatMap <| fun first ->
-                                    match first with
-                                    | Ok(value, isFirst) ->
-                                        let loser = if isFirst then fiber2 else fiber1
-                                        (loser.Interrupt ExplicitInterrupt "Lost race")
-                                            .Ignore()
-                                            .As value
-                                    | Error _ ->
-                                        channel.Read().FlatMap <| fun second ->
-                                            match second with
-                                            | Ok(value, _) -> FIO.succeed value
-                                            | Error error -> FIO.fail error
+                        (FIO.joinFirst [fiber1.Context; fiber2.Context]).FlatMap <| fun index ->
+                            let winner, loser = if index = 0 then fiber1, fiber2 else fiber2, fiber1
+                            winner.Await().FlatMap <| fun result ->
+                                match result with
+                                | Succeeded value ->
+                                    (loser.Interrupt ExplicitInterrupt "Lost race")
+                                        .Ignore()
+                                        .As value
+                                | Failed _
+                                | Interrupted _ ->
+                                    loser.Join()

--- a/src/FIO/DSL/Extensions.fs
+++ b/src/FIO/DSL/Extensions.fs
@@ -151,9 +151,7 @@ module Extensions =
         /// Returns an effect that interrupts the current fiber if this effect fails, using a message derived from the error.
         member inline this.OrInterrupt<'E1> (toMessage: 'E -> string) : FIO<'A, 'E1> =
             this.CatchAll <| fun error ->
-                FIO.interrupt(
-                    ResourceExhaustion(toMessage error))
-                    "Fiber interrupted due to unrecoverable error"
+                FIO.interrupt ExplicitInterrupt (toMessage error)
 
         /// Returns an effect that fails with the given error unless this effect's success value satisfies the predicate.
         member inline this.FilterOrFail (predicate: 'A -> bool) (error: 'E) : FIO<'A, 'E> =
@@ -177,7 +175,7 @@ module Extensions =
         member inline this.FilterOrInterrupt (predicate: 'A -> bool) (message: string) : FIO<'A, 'E> =
             this.FlatMap <| fun value ->
                 if predicate value then FIO.succeed value
-                else FIO.interrupt (ResourceExhaustion message) message
+                else FIO.interrupt ExplicitInterrupt message
 
         /// Returns an effect that fails when the given function produces an error for this effect's success value.
         member inline this.Reject (func: 'A -> 'E option) : FIO<'A, 'E> =
@@ -394,9 +392,11 @@ module Extensions =
                 this.CatchAll <| fun _ -> loop ()
             loop ()
 
-        /// Returns an effect that runs this effect n times, yielding the last result.
+        /// Returns an effect that runs this effect n times, yielding the last result. Interrupts the fiber when n is less than 1.
         member this.RepeatN (n: int) : FIO<'A, 'E> =
-            if n <= 1 then
+            if n < 1 then
+                FIO.interrupt (InvalidArgument("n", "must be >= 1")) "Invalid argument: n must be >= 1"
+            elif n = 1 then
                 this
             else
                 this.FlatMap <|fun _ ->

--- a/src/FIO/DSL/Factories.fs
+++ b/src/FIO/DSL/Factories.fs
@@ -373,57 +373,55 @@ module FIO =
             acc.CatchAll <| fun _ ->
                 effect) head
 
-    /// Runs the given effects concurrently and returns the first to succeed, interrupting the rest.
-    let inline raceAll<'A, 'E> (effects: seq<FIO<'A, 'E>>) : FIO<'A, 'E> =
+    /// Runs the given effects concurrently and returns the first to succeed, interrupting the rest. Racers that fail or are interrupted retire from the race; when no racer succeeds, this effect fails with the last error observed, or propagates an interruption when every racer was interrupted.
+    let raceAll<'A, 'E> (effects: seq<FIO<'A, 'E>>) : FIO<'A, 'E> =
         suspend <| fun () ->
             let arr = Seq.toArray effects
 
             if arr.Length = 0 then
                 interrupt (InvalidArgument("effects", "sequence must not be empty")) "Cannot race an empty sequence"
-
             elif arr.Length = 1 then
                 arr[0]
             else
-                let resultChannel = Channel<Result<'A * int, 'E>>()
+                let rec forkAll i (forked: Fiber<'A, 'E> list) : FIO<Fiber<'A, 'E> list, 'E> =
+                    if i >= arr.Length then
+                        succeed (List.rev forked)
+                    else
+                        arr[i].Fork().FlatMap <| fun fiber ->
+                            forkAll (i + 1) (fiber :: forked)
 
-                let signal (idx: int) (fiber: Fiber<'A, 'E>) : FIO<unit, 'E> =
-                    fiber.Await().FlatMap <| fun result ->
-                        match result with
-                        | Succeeded value ->
-                            resultChannel.Write(Ok(value, idx)).FlatMap <| fun _ -> unit ()
-                        | Failed error ->
-                            resultChannel.Write(Error error).FlatMap <| fun _ -> unit ()
-                        | Interrupted _ -> unit ()
-
-                let interruptOthers (fiberArr: Fiber<'A, 'E> array) (winnerIdx: int) : FIO<unit, 'E> =
-                    let rec loop i =
-                        if i >= fiberArr.Length then
-                            unit ()
-                        elif i = winnerIdx then
-                            loop (i + 1)
-                        else
-                            (fiberArr[i].Interrupt ExplicitInterrupt "Lost race")
+                let interruptAll (fibers: Fiber<'A, 'E> list) : FIO<unit, 'E> =
+                    let rec go remaining =
+                        match remaining with
+                        | [] -> unit ()
+                        | (fiber: Fiber<'A, 'E>) :: rest ->
+                            (fiber.Interrupt ExplicitInterrupt "Lost race")
                                 .CatchAll(fun _ -> unit ())
-                                .FlatMap <| fun () -> loop (i + 1)
-                    loop 0
+                                .FlatMap <| fun () -> go rest
+                    go fibers
 
-                let rec receive (received: int) (fiberArr: Fiber<'A, 'E> array) : FIO<'A, 'E> =
-                    resultChannel.Read().FlatMap <| fun result ->
-                        match result with
-                        | Ok(value, winnerIdx) ->
-                            (interruptOthers fiberArr winnerIdx).FlatMap <| fun () -> succeed value
-                        | Error error ->
-                            if received + 1 >= arr.Length then
-                                fail error
-                            else
-                                receive (received + 1) fiberArr
+                let rec awaitFirstSuccess (remaining: Fiber<'A, 'E> list) (lastError: 'E voption) : FIO<'A, 'E> =
+                    match remaining with
+                    | [] ->
+                        match lastError with
+                        | ValueSome error -> fail error
+                        | ValueNone -> interrupt ExplicitInterrupt "Every racer was interrupted"
+                    | _ ->
+                        (joinFirst (remaining |> List.map (fun fiber -> fiber.Context))).FlatMap <| fun index ->
+                            let settled = remaining[index]
+                            let rest =
+                                remaining
+                                |> List.indexed
+                                |> List.choose (fun (i, fiber) -> if i = index then None else Some fiber)
 
-                let forkAllEff = collectAll (arr |> Array.map _.Fork())
+                            settled.Await().FlatMap <| fun result ->
+                                match result with
+                                | Succeeded value ->
+                                    (interruptAll rest).FlatMap <| fun () -> succeed value
+                                | Failed error ->
+                                    awaitFirstSuccess rest (ValueSome error)
+                                | Interrupted _ ->
+                                    awaitFirstSuccess rest lastError
 
-                forkAllEff.FlatMap <| fun fibers ->
-                    let fiberArr = List.toArray fibers
-                    let startSignalsEff =
-                        fibers
-                        |> List.mapi (fun i fiber -> (signal i fiber).Fork().Map(fun _ -> ()))
-                        |> collectAllDiscard
-                    startSignalsEff.FlatMap <| fun () -> receive 0 fiberArr
+                (forkAll 0 []).FlatMap <| fun fibers ->
+                    awaitFirstSuccess fibers ValueNone

--- a/src/FIO/DSL/Factories.fs
+++ b/src/FIO/DSL/Factories.fs
@@ -119,6 +119,18 @@ module FIO =
     let never<'A, 'E> () : FIO<'A, 'E> =
         NeverEffect<'A, 'E>.Effect
 
+    let internal joinFirst<'E> (fiberContexts: FiberContext list) : FIO<int, 'E> =
+        if List.isEmpty fiberContexts then
+            interrupt (InvalidArgument("fiberContexts", "list must not be empty")) "Cannot join the first of an empty list of fibers"
+        else
+            JoinFirst fiberContexts
+
+    let internal joinAllFailFast<'E> (fiberContexts: FiberContext[]) : FIO<int voption, 'E> =
+        if Array.isEmpty fiberContexts then
+            succeed ValueNone
+        else
+            JoinAllFailFast fiberContexts
+
     /// Acquires a resource, uses it, and releases it afterwards on success, failure, or interruption.
     let inline acquireReleaseWith<'A, 'A1, 'E>
         (acquire: FIO<'A1, 'E>)
@@ -156,43 +168,54 @@ module FIO =
             loop 0
 
     /// Runs the given effect for each item concurrently, collecting the results into a list.
-    let inline forEachPar<'A, 'A1, 'E> (items: seq<'A1>) (func: 'A1 -> FIO<'A, 'E>) : FIO<'A list, 'E> =
+    let forEachPar<'A, 'A1, 'E> (items: seq<'A1>) (func: 'A1 -> FIO<'A, 'E>) : FIO<'A list, 'E> =
         suspend <| fun () ->
             let arr = Seq.toArray items
-            let forked = ResizeArray<Fiber<'A, 'E>> arr.Length
-            let results = ResizeArray<'A> arr.Length
 
-            let rec forkAll i : FIO<Fiber<'A, 'E> list, 'E> =
-                if i >= arr.Length then
-                    succeed (List.ofSeq forked)
-                else
-                    (func arr[i]).Fork().FlatMap <| fun fiber ->
-                        forked.Add fiber
-                        forkAll (i + 1)
+            if arr.Length = 0 then
+                succeed []
+            else
+                let rec forkAll i (forked: Fiber<'A, 'E> list) : FIO<Fiber<'A, 'E>[], 'E> =
+                    if i >= arr.Length then
+                        succeed (List.rev forked |> List.toArray)
+                    else
+                        (func arr[i]).Fork().FlatMap <| fun fiber ->
+                            forkAll (i + 1) (fiber :: forked)
 
-            let inline interruptOne (fiber: Fiber<'A, 'E>) : FIO<unit, 'E> =
-                (fiber.Interrupt ExplicitInterrupt "forEachPar peer failed")
-                    .CatchAll(fun _ -> unit ())
+                (forkAll 0 []).FlatMap <| fun fiberArr ->
+                    let interruptAll () : FIO<unit, 'E> =
+                        let rec loop i =
+                            if i >= fiberArr.Length then
+                                unit ()
+                            else
+                                (fiberArr[i].Interrupt ExplicitInterrupt "forEachPar peer failed")
+                                    .CatchAll(fun _ -> unit ())
+                                    .FlatMap <| fun () -> loop (i + 1)
+                        loop 0
 
-            let rec interruptAll (fibers: Fiber<'A, 'E> list) : FIO<unit, 'E> =
-                match fibers with
-                | [] -> unit ()
-                | fiber :: rest ->
-                    (interruptOne fiber).FlatMap <| fun () ->
-                        interruptAll rest
+                    let contexts = fiberArr |> Array.map (fun fiber -> fiber.Context)
 
-            let rec joinAll (fibers: Fiber<'A, 'E> list) : FIO<'A list, 'E> =
-                match fibers with
-                | [] -> succeed (List.ofSeq results)
-                | fiber :: rest ->
-                    (fiber.Join().FlatMap <| fun value ->
-                        results.Add value
-                        joinAll rest).CatchAll(fun error ->
-                            (interruptAll rest).FlatMap <| fun () ->
-                                fail error)
+                    (joinAllFailFast contexts).FlatMap <| fun outcome ->
+                        match outcome with
+                        | ValueNone ->
+                            let rec collect i (acc: 'A list) : FIO<'A list, 'E> =
+                                if i < 0 then
+                                    succeed acc
+                                else
+                                    fiberArr[i].Join().FlatMap <| fun value ->
+                                        collect (i - 1) (value :: acc)
 
-            (forkAll 0).FlatMap <| fun fibers ->
-                joinAll fibers
+                            collect (arr.Length - 1) []
+                        | ValueSome index ->
+                            fiberArr[index].Await().FlatMap <| fun result ->
+                                (interruptAll ()).FlatMap <| fun () ->
+                                    match result with
+                                    | Failed error -> fail error
+                                    | Interrupted ex -> interrupt ex.cause ex.message
+                                    | Succeeded _ ->
+                                        interrupt
+                                            ExplicitInterrupt
+                                            "joinAllFailFast returned the index of a succeeded fiber"
 
     /// Runs the given effect for each item concurrently, discarding the results.
     let inline forEachParDiscard<'A, 'A1, 'E> (items: seq<'A1>) (func: 'A1 -> FIO<'A, 'E>) : FIO<unit, 'E> =

--- a/src/FIO/Runtime/DirectRuntime.fs
+++ b/src/FIO/Runtime/DirectRuntime.fs
@@ -139,6 +139,67 @@ type DirectRuntime() =
                                             ExplicitInterrupt,
                                             "Fiber was interrupted while blocked on a fiber join."
                                         )))
+                            | HandleJoinFirst fiberContexts ->
+                                let contexts = List.toArray fiberContexts
+                                try
+                                    let whenAny =
+                                        Task.WhenAny(contexts |> Array.map (fun fiberContext -> fiberContext.Task :> Task))
+                                    let! _ =
+                                        if state.InterruptionSuppressed > 0 then
+                                            whenAny
+                                        else
+                                            whenAny.WaitAsync currentFiberContext.CancellationToken
+                                    let index = contexts |> Array.findIndex (fun fiberContext -> fiberContext.IsTerminal())
+                                    processOutcome
+                                        &state
+                                        onSuccessComplete
+                                        onErrorComplete
+                                        (OutcomeSucceeded(box index))
+                                with
+                                | :? OperationCanceledException when
+                                    currentFiberContext.CancellationToken.IsCancellationRequested ->
+                                    processOutcome
+                                        &state
+                                        onSuccessComplete
+                                        onErrorComplete
+                                        (OutcomeInterrupted (FiberInterruptedException(
+                                            currentFiberContext.Id,
+                                            ExplicitInterrupt,
+                                            "Fiber was interrupted while blocked on a fiber join."
+                                        )))
+                            | HandleJoinAllFailFast fiberContexts ->
+                                match tryCompleteJoinAll fiberContexts with
+                                | ValueSome outcome ->
+                                    processOutcome
+                                        &state
+                                        onSuccessComplete
+                                        onErrorComplete
+                                        (OutcomeSucceeded(box outcome))
+                                | ValueNone ->
+                                    try
+                                        let! outcome =
+                                            awaitJoinAllSettled
+                                                fiberContexts
+                                                (state.InterruptionSuppressed > 0)
+                                                currentFiberContext
+                                                currentFiberContext.CancellationToken
+                                        processOutcome
+                                            &state
+                                            onSuccessComplete
+                                            onErrorComplete
+                                            outcome
+                                    with
+                                    | :? OperationCanceledException when
+                                        currentFiberContext.CancellationToken.IsCancellationRequested ->
+                                        processOutcome
+                                            &state
+                                            onSuccessComplete
+                                            onErrorComplete
+                                            (OutcomeInterrupted (FiberInterruptedException(
+                                                currentFiberContext.Id,
+                                                ExplicitInterrupt,
+                                                "Fiber was interrupted while blocked on a fiber join."
+                                            )))
                             | HandleAwaitTask(task, onError) ->
                                 try
                                     let! value =

--- a/src/FIO/Runtime/InterpreterCore.fs
+++ b/src/FIO/Runtime/InterpreterCore.fs
@@ -304,9 +304,6 @@ let parkJoinFirstOnHooks
         parkBlockingWaiter currentFiberContext suppressed workItem (fun wi ->
             activeWorkItemQueue.WriteAsync wi |> ignore)
 
-    // A repeated park over surviving fibers (raceAll) can find a fiber whose previous, already
-    // claimed hook consumed the once-per-context fire gate; the explicit recheck rescues a
-    // fiber that turned terminal without the new hook firing.
     for fiberContext in fiberContexts do
         fiberContext.SetOnTerminal <| fun () ->
             if waiter.TryClaim() then

--- a/src/FIO/Runtime/InterpreterCore.fs
+++ b/src/FIO/Runtime/InterpreterCore.fs
@@ -2,8 +2,10 @@ module internal FIO.Runtime.InterpreterCore
 
 open FIO.DSL
 
+open System.Threading
 open System.Threading.Tasks
 open System.Collections.Generic
+open System.Runtime.CompilerServices
 
 [<Struct; NoComparison; NoEquality>]
 type InterpreterState =
@@ -28,6 +30,8 @@ type RuntimeCase =
     | HandleReadChan of channel: Channel<obj>
     | HandleForkEffect of effect: FIO<obj, obj> * fiber: obj * fiberContext: FiberContext
     | HandleJoinFiber of fiberContext: FiberContext
+    | HandleJoinFirst of fiberContexts: FiberContext list
+    | HandleJoinAllFailFast of allFiberContexts: FiberContext[]
     | HandleAwaitTask of task: Task<obj> * onError: (exn -> obj)
 
 [<Struct; NoComparison; NoEquality>]
@@ -194,6 +198,10 @@ let inline handleSharedCase
         ValueSome(HandleForkEffect(effect, fiber, fiberContext))
     | JoinFiber fiberContext ->
         ValueSome(HandleJoinFiber fiberContext)
+    | JoinFirst fiberContexts ->
+        ValueSome(HandleJoinFirst fiberContexts)
+    | JoinAllFailFast fiberContexts ->
+        ValueSome(HandleJoinAllFailFast fiberContexts)
     | AwaitTask(task, onError) ->
         ValueSome(HandleAwaitTask(task, onError))
 
@@ -220,3 +228,126 @@ let parkBlockingWaiter
                     ())
         waiter.SetRegistration registration
     waiter
+
+[<MethodImpl(MethodImplOptions.NoInlining)>]
+let tryCompleteJoinAll (fiberContexts: FiberContext[]) =
+    let mutable firstFailure = -1
+    let mutable allSettled = true
+
+    for i in 0 .. fiberContexts.Length - 1 do
+        let fiberContext = fiberContexts[i]
+
+        if fiberContext.IsTerminal() && fiberContext.Task.IsCompleted then
+            if firstFailure = -1 then
+                match fiberContext.Task.Result with
+                | Error _ -> firstFailure <- i
+                | Ok _ -> ()
+        else
+            allSettled <- false
+
+    if firstFailure >= 0 then ValueSome(ValueSome firstFailure)
+    elif allSettled then ValueSome ValueNone
+    else ValueNone
+
+let registerJoinAllLatch (fiberContexts: FiberContext[]) (signal: unit -> unit) =
+    let latch = JoinAllLatch(fiberContexts.Length, signal)
+
+    for fiberContext in fiberContexts do
+        fiberContext.SetOnTerminal <| fun () -> latch.OnChildTerminal fiberContext
+
+[<MethodImpl(MethodImplOptions.NoInlining)>]
+let tryFindTerminalIndex (fiberContexts: FiberContext list) =
+    let mutable index = 0
+    let mutable result = -1
+    let mutable remaining = fiberContexts
+
+    while result < 0 && not remaining.IsEmpty do
+        if remaining.Head.IsTerminal() then
+            result <- index
+        else
+            index <- index + 1
+            remaining <- remaining.Tail
+
+    result
+
+[<MethodImpl(MethodImplOptions.NoInlining)>]
+let parkJoinFirstOnQueue
+    (fiberContexts: FiberContext list)
+    (currentFiberContext: FiberContext)
+    (suppressed: int)
+    (workItem: WorkItem)
+    (activeWorkItemQueue: MailboxQueue<WorkItem>) =
+    let waiter =
+        parkBlockingWaiter currentFiberContext suppressed workItem <| fun wi ->
+            activeWorkItemQueue.WriteAsync wi |> ignore
+
+    for fiberContext in fiberContexts do
+        let addVt = fiberContext.AddBlockingWorkItem waiter
+
+        if not addVt.IsCompletedSuccessfully then
+            addVt.AsTask() |> ignore
+
+    for fiberContext in fiberContexts do
+        let rescheduleVt = fiberContext.TryRescheduleBlockingWorkItems activeWorkItemQueue
+
+        if not rescheduleVt.IsCompletedSuccessfully then
+            rescheduleVt.AsTask() |> ignore
+
+[<MethodImpl(MethodImplOptions.NoInlining)>]
+let parkJoinFirstOnHooks
+    (fiberContexts: FiberContext list)
+    (currentFiberContext: FiberContext)
+    (suppressed: int)
+    (workItem: WorkItem)
+    (activeWorkItemQueue: MailboxQueue<WorkItem>) =
+    let waiter =
+        parkBlockingWaiter currentFiberContext suppressed workItem (fun wi ->
+            activeWorkItemQueue.WriteAsync wi |> ignore)
+
+    for fiberContext in fiberContexts do
+        fiberContext.SetOnTerminal <| fun () ->
+            if waiter.TryClaim() then
+                activeWorkItemQueue.WriteAsync waiter.WorkItem |> ignore
+
+[<MethodImpl(MethodImplOptions.NoInlining)>]
+let parkJoinAllFailFastOnQueue
+    (fiberContexts: FiberContext[])
+    (currentFiberContext: FiberContext)
+    (suppressed: int)
+    (workItem: WorkItem)
+    (activeWorkItemQueue: MailboxQueue<WorkItem>) =
+    let waiter =
+        parkBlockingWaiter currentFiberContext suppressed workItem (fun wi ->
+            activeWorkItemQueue.WriteAsync wi |> ignore)
+
+    registerJoinAllLatch fiberContexts <| fun () ->
+        if waiter.TryClaim() then
+            activeWorkItemQueue.WriteAsync waiter.WorkItem |> ignore
+
+[<MethodImpl(MethodImplOptions.NoInlining)>]
+let awaitJoinAllSettled
+    (fiberContexts: FiberContext[])
+    (suppressed: bool)
+    (currentFiberContext: FiberContext)
+    (cancellationToken: CancellationToken) =
+    task {
+        let completionSource =
+            TaskCompletionSource<unit> TaskCreationOptions.RunContinuationsAsynchronously
+
+        registerJoinAllLatch fiberContexts (fun () -> completionSource.TrySetResult() |> ignore)
+
+        let! _ =
+            if suppressed then completionSource.Task
+            else completionSource.Task.WaitAsync cancellationToken
+
+        match tryCompleteJoinAll fiberContexts with
+        | ValueSome outcome ->
+            return OutcomeSucceeded <| box outcome
+        | ValueNone ->
+            return
+                OutcomeInterrupted(
+                    FiberInterruptedException(
+                        currentFiberContext.Id,
+                        ExplicitInterrupt,
+                        "JoinAllFailFast signalled without a settled outcome."))
+    }

--- a/src/FIO/Runtime/InterpreterCore.fs
+++ b/src/FIO/Runtime/InterpreterCore.fs
@@ -304,10 +304,16 @@ let parkJoinFirstOnHooks
         parkBlockingWaiter currentFiberContext suppressed workItem (fun wi ->
             activeWorkItemQueue.WriteAsync wi |> ignore)
 
+    // A repeated park over surviving fibers (raceAll) can find a fiber whose previous, already
+    // claimed hook consumed the once-per-context fire gate; the explicit recheck rescues a
+    // fiber that turned terminal without the new hook firing.
     for fiberContext in fiberContexts do
         fiberContext.SetOnTerminal <| fun () ->
             if waiter.TryClaim() then
                 activeWorkItemQueue.WriteAsync waiter.WorkItem |> ignore
+
+        if fiberContext.IsTerminal() && waiter.TryClaim() then
+            activeWorkItemQueue.WriteAsync waiter.WorkItem |> ignore
 
 [<MethodImpl(MethodImplOptions.NoInlining)>]
 let parkJoinAllFailFastOnQueue

--- a/src/FIO/Runtime/PollingRuntime.fs
+++ b/src/FIO/Runtime/PollingRuntime.fs
@@ -16,6 +16,9 @@ module private PollingTuning =
     let ChannelYieldMissThreshold = 65_536
     let FiberSpinWaitIterations = 128
     let FiberSpinMissThreshold = 512
+    let FiberColdMissThreshold = 65_536
+    let FiberColdSpinWaitIterations = 10
+    let FiberColdWatchLimit = 40_000
 
 type private EvaluationWorkerConfig =
     {
@@ -132,7 +135,7 @@ and internal BlockingWorker(config: BlockingWorkerConfig, workerId: int) =
                 do! addVt.AsTask()
         }
 
-    let applyBackoff (maxChannelMiss: int, maxFiberMiss: int) =
+    let applyBackoff (maxChannelMiss: int, maxFiberMiss: int, minFiberMiss: int) =
         task {
             if maxChannelMiss > 0 then
                 if maxChannelMiss < PollingTuning.ChannelSpinMissThreshold then
@@ -144,8 +147,15 @@ and internal BlockingWorker(config: BlockingWorkerConfig, workerId: int) =
             elif maxFiberMiss > 0 then
                 if maxFiberMiss < PollingTuning.FiberSpinMissThreshold then
                     Thread.SpinWait PollingTuning.FiberSpinWaitIterations
-                else
+                elif minFiberMiss < PollingTuning.FiberColdMissThreshold || channelPending.Count > 0 then
                     do! Task.Yield()
+                else
+                    let mutable watched = 0
+
+                    while watched < PollingTuning.FiberColdWatchLimit
+                          && config.BlockingEntryQueue.Count = 0 do
+                        Thread.SpinWait PollingTuning.FiberColdSpinWaitIterations
+                        watched <- watched + 1
         }
 
     let processBatch () =
@@ -153,11 +163,14 @@ and internal BlockingWorker(config: BlockingWorkerConfig, workerId: int) =
             let mutable processed = 0
             let mutable maxChannelMiss = 0
             let mutable maxFiberMiss = 0
+            let mutable minFiberMiss = Int32.MaxValue
             let mutable entry = Unchecked.defaultof<BlockingEntry>
             let mutable hasEntry = true
+            let mutable preferChannel = preferChannelFirst
 
             while processed < batchSize && hasEntry do
-                hasEntry <- tryTakePending (preferChannelFirst, &entry)
+                hasEntry <- tryTakePending (preferChannel, &entry)
+                preferChannel <- not preferChannel
 
                 if hasEntry then
                     processed <- processed + 1
@@ -179,10 +192,13 @@ and internal BlockingWorker(config: BlockingWorkerConfig, workerId: int) =
                             if missed.MissCount > maxFiberMiss then
                                 maxFiberMiss <- missed.MissCount
 
+                            if missed.MissCount < minFiberMiss then
+                                minFiberMiss <- missed.MissCount
+
             preferChannelFirst <- not preferChannelFirst
 
             if maxChannelMiss > 0 || maxFiberMiss > 0 then
-                do! applyBackoff (maxChannelMiss, maxFiberMiss)
+                do! applyBackoff (maxChannelMiss, maxFiberMiss, minFiberMiss)
         }
 
     let tryDrainIncoming () =
@@ -379,6 +395,34 @@ and PollingRuntime(config: WorkerConfig) as this =
                                         WorkItemPool.Rent(state.Effect, currentFiberContext, state.ContStack)
                                     newWorkItem.InterruptionSuppressed <- state.InterruptionSuppressed
                                     do! blockingWorker.RescheduleForBlocking <| BlockingFiber(fiberContext, newWorkItem)
+                                    state.Completed <- true
+                            | HandleJoinFirst fiberContexts ->
+                                match tryFindTerminalIndex fiberContexts with
+                                | index when index >= 0 ->
+                                    processOutcome
+                                        &state
+                                        onSuccessComplete
+                                        onErrorComplete
+                                        (OutcomeSucceeded(box index))
+                                | _ ->
+                                    let newWorkItem =
+                                        WorkItemPool.Rent(state.Effect, currentFiberContext, state.ContStack)
+                                    newWorkItem.InterruptionSuppressed <- state.InterruptionSuppressed
+                                    parkJoinFirstOnHooks fiberContexts currentFiberContext state.InterruptionSuppressed newWorkItem activeWorkItemQueue
+                                    state.Completed <- true
+                            | HandleJoinAllFailFast fiberContexts ->
+                                match tryCompleteJoinAll fiberContexts with
+                                | ValueSome outcome ->
+                                    processOutcome
+                                        &state
+                                        onSuccessComplete
+                                        onErrorComplete
+                                        (OutcomeSucceeded(box outcome))
+                                | ValueNone ->
+                                    let newWorkItem =
+                                        WorkItemPool.Rent(state.Effect, currentFiberContext, state.ContStack)
+                                    newWorkItem.InterruptionSuppressed <- state.InterruptionSuppressed
+                                    parkJoinAllFailFastOnQueue fiberContexts currentFiberContext state.InterruptionSuppressed newWorkItem activeWorkItemQueue
                                     state.Completed <- true
                             | HandleAwaitTask(awaited, onError) ->
                                 let waited =

--- a/src/FIO/Runtime/SignalingRuntime.fs
+++ b/src/FIO/Runtime/SignalingRuntime.fs
@@ -215,6 +215,34 @@ and SignalingRuntime(config: WorkerConfig) as this =
                                     do! fiberContext.AddBlockingWorkItem waiter
                                     let! _ = fiberContext.TryRescheduleBlockingWorkItems activeWorkItemQueue
                                     state.Completed <- true
+                            | HandleJoinFirst fiberContexts ->
+                                match tryFindTerminalIndex fiberContexts with
+                                | index when index >= 0 ->
+                                    processOutcome
+                                        &state
+                                        onSuccessComplete
+                                        onErrorComplete
+                                        (OutcomeSucceeded(box index))
+                                | _ ->
+                                    let newWorkItem =
+                                        WorkItemPool.Rent(state.Effect, currentFiberContext, state.ContStack)
+                                    newWorkItem.InterruptionSuppressed <- state.InterruptionSuppressed
+                                    parkJoinFirstOnQueue fiberContexts currentFiberContext state.InterruptionSuppressed newWorkItem activeWorkItemQueue
+                                    state.Completed <- true
+                            | HandleJoinAllFailFast fiberContexts ->
+                                match tryCompleteJoinAll fiberContexts with
+                                | ValueSome outcome ->
+                                    processOutcome
+                                        &state
+                                        onSuccessComplete
+                                        onErrorComplete
+                                        (OutcomeSucceeded(box outcome))
+                                | ValueNone ->
+                                    let newWorkItem =
+                                        WorkItemPool.Rent(state.Effect, currentFiberContext, state.ContStack)
+                                    newWorkItem.InterruptionSuppressed <- state.InterruptionSuppressed
+                                    parkJoinAllFailFastOnQueue fiberContexts currentFiberContext state.InterruptionSuppressed newWorkItem activeWorkItemQueue
+                                    state.Completed <- true
                             | HandleAwaitTask(awaited, onError) ->
                                 let waited =
                                     if state.InterruptionSuppressed > 0 then

--- a/src/FIO/Runtime/WorkStealingRuntime.fs
+++ b/src/FIO/Runtime/WorkStealingRuntime.fs
@@ -423,6 +423,53 @@ and WorkStealingRuntime(config: WorkerConfig) as this =
                                     if rescheduled then
                                         scheduler.SignalWork()
                                     state.Completed <- true
+                            | HandleJoinFirst fiberContexts ->
+                                match tryFindTerminalIndex fiberContexts with
+                                | index when index >= 0 ->
+                                    processOutcome
+                                        &state
+                                        onSuccessComplete
+                                        onErrorComplete
+                                        (OutcomeSucceeded(box index))
+                                | _ ->
+                                    let newWorkItem =
+                                        scheduler.RentWorkItem(workerId, state.Effect, currentFiberContext, state.ContStack)
+                                    newWorkItem.InterruptionSuppressed <- state.InterruptionSuppressed
+                                    let waiter =
+                                        parkBlockingWaiter currentFiberContext state.InterruptionSuppressed newWorkItem (fun wi ->
+                                            scheduler.GlobalQueue.WriteAsync wi |> ignore
+                                            scheduler.SignalWork())
+                                    for fiberContext in fiberContexts do
+                                        do! fiberContext.AddBlockingWorkItem waiter
+                                    let mutable anyRescheduled = false
+                                    for fiberContext in fiberContexts do
+                                        let! rescheduled = fiberContext.TryRescheduleBlockingWorkItems scheduler.GlobalQueue
+                                        anyRescheduled <- anyRescheduled || rescheduled
+                                    if anyRescheduled then
+                                        scheduler.SignalWork()
+                                    state.Completed <- true
+                            | HandleJoinAllFailFast fiberContexts ->
+                                match tryCompleteJoinAll fiberContexts with
+                                | ValueSome outcome ->
+                                    processOutcome
+                                        &state
+                                        onSuccessComplete
+                                        onErrorComplete
+                                        (OutcomeSucceeded(box outcome))
+                                | ValueNone ->
+                                    let newWorkItem =
+                                        scheduler.RentWorkItem(workerId, state.Effect, currentFiberContext, state.ContStack)
+                                    newWorkItem.InterruptionSuppressed <- state.InterruptionSuppressed
+                                    let waiter =
+                                        parkBlockingWaiter currentFiberContext state.InterruptionSuppressed newWorkItem (fun wi ->
+                                            scheduler.GlobalQueue.WriteAsync wi |> ignore
+                                            scheduler.SignalWork())
+                                    registerJoinAllLatch fiberContexts (fun () ->
+                                        if waiter.TryClaim() then
+                                            let wi = waiter.WorkItem
+                                            scheduler.GlobalQueue.WriteAsync wi |> ignore
+                                            scheduler.SignalWork())
+                                    state.Completed <- true
                             | HandleAwaitTask(awaited, onError) ->
                                 let waited =
                                     if state.InterruptionSuppressed > 0 then
@@ -437,11 +484,6 @@ and WorkStealingRuntime(config: WorkerConfig) as this =
                                         onErrorComplete
                                         (OutcomeSucceeded waited.Result)
                                 else
-                                    // Park asynchronously rather than blocking this worker for the
-                                    // duration of the task: when the task completes, reschedule the
-                                    // fiber onto the global queue. The continuation may run on a
-                                    // foreign thread, so it must not touch the per-worker pools or
-                                    // deque (only the thread-safe global queue and wake signal).
                                     let fiberContext = currentFiberContext
                                     let suppressed = state.InterruptionSuppressed
                                     let contStack = state.ContStack

--- a/tests/FIO.Tests/DSL/CETests.fs
+++ b/tests/FIO.Tests/DSL/CETests.fs
@@ -1134,7 +1134,7 @@ let ceTests =
 
                 Expect.equal result error "and! should propagate error from first effect"
 
-            testPropertyWithConfig fsCheckConfigFast "MergeSources - and! with multiple errors returns first error"
+            testPropertyWithConfig fsCheckConfigFast "MergeSources - and! with multiple errors surfaces one of the errors"
             <| fun (runtime: FIORuntime, err1: int, err2: int) ->
                 let effect =
                     fio {
@@ -1145,7 +1145,7 @@ let ceTests =
 
                 let result = runtime.Run(effect).UnsafeError()
 
-                Expect.equal result err1 "and! should return first error when multiple effects fail"
+                Expect.isTrue (result = err1 || result = err2) "and! surfaces one of the concurrent errors"
 
             testAllRuntimes "MergeSources - and! executes in parallel" (fun runtime ->
                 let mutable firstRan = false

--- a/tests/FIO.Tests/DSL/ExtensionTests.fs
+++ b/tests/FIO.Tests/DSL/ExtensionTests.fs
@@ -707,7 +707,9 @@ let extensionTests =
                     fiber.Task() |> Async.AwaitTask |> Async.RunSynchronously
 
                 match fiberResult with
-                | Interrupted _ -> ()
+                | Interrupted ex ->
+                    Expect.equal ex.cause ExplicitInterrupt "OrInterrupt should interrupt with ExplicitInterrupt"
+                    Expect.stringContains ex.message "Interrupted: error" "OrInterrupt should carry the derived message"
                 | _ -> failtest "OrInterrupt should convert error to interrupt"
 
             // ─── Filter / partial functions ─────────────────────────────────────────
@@ -793,7 +795,9 @@ let extensionTests =
 
                 let interrupted =
                     match outcome.Task() |> Async.AwaitTask |> Async.RunSynchronously with
-                    | Interrupted _ -> true
+                    | Interrupted ex ->
+                        Expect.equal ex.cause ExplicitInterrupt "FilterOrInterrupt should interrupt with ExplicitInterrupt"
+                        true
                     | _ -> false
 
                 Expect.isTrue interrupted "FilterOrInterrupt should interrupt the fiber when predicate rejects"
@@ -1565,6 +1569,17 @@ let extensionTests =
                 Expect.equal count 5 "RepeatN should execute 5 times"
                 Expect.equal result 5 "RepeatN should return last result"
 
+            testAllRuntimes "RepeatN - n=0 interrupts with InvalidArgument" (fun runtime ->
+                let effect = FIO.succeed 1
+                let result = runtime.Run(effect.RepeatN 0).UnsafeResult()
+
+                match result with
+                | Interrupted ex ->
+                    match ex.cause with
+                    | InvalidArgument _ -> ()
+                    | cause -> failtest $"RepeatN 0 should interrupt with InvalidArgument, got cause: %A{cause}"
+                | other -> failtest $"RepeatN 0 should interrupt with InvalidArgument, got: %A{other}")
+
             testPropertyWithConfig fsCheckConfig "RepeatN - n=1 executes exactly once"
             <| fun (runtime: FIORuntime, value: int) ->
                 let mutable count = 0
@@ -1879,6 +1894,46 @@ let extensionTests =
                 let result = runtime.Run(bounded).UnsafeSuccess()
 
                 Expect.equal result 42 "RaceFirst should interrupt the loser and run its Ensuring finalizer")
+
+            testAllRuntimes "Race - a failed first-settler does not win; the race yields the other side's success" (fun runtime ->
+                let failing = FIO.fail (exn "fast failure")
+                let succeeding =
+                    (FIO.sleep (TimeSpan.FromMilliseconds 100.0) id).FlatMap(fun () -> FIO.succeed 5)
+                let effect = failing.Race succeeding
+
+                let bounded =
+                    effect.TimeoutFail (exn "timeout") (TimeSpan.FromSeconds 5.0) id
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.equal result 5 "Race is first-to-succeed: a fast failure must not win")
+
+            testAllRuntimes "Race - an interrupted first-settler does not win; the race yields the other side's success" (fun runtime ->
+                let interruptedSide =
+                    (FIO.sleep (TimeSpan.FromMilliseconds 30.0) id)
+                        .FlatMap(fun () -> FIO.interrupt ExplicitInterrupt "settled first")
+                let succeeding =
+                    (FIO.sleep (TimeSpan.FromMilliseconds 100.0) id).FlatMap(fun () -> FIO.succeed 5)
+                let effect = interruptedSide.Race succeeding
+
+                let bounded =
+                    effect.TimeoutFail (exn "timeout") (TimeSpan.FromSeconds 5.0) id
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.equal result 5 "Race is first-to-succeed: an early interruption must not win")
+
+            testAllRuntimes "Race - waits on a never-settling loser when the winner fails (documented first-to-succeed semantics)" (fun runtime ->
+                let failing = FIO.fail (exn "fast failure")
+                let never = FIO.never<int, exn> ()
+                let effect = failing.Race never
+
+                let bounded =
+                    effect.TimeoutFail (exn "timeout") (TimeSpan.FromMilliseconds 500.0) id
+
+                let result = runtime.Run(bounded).UnsafeError()
+
+                Expect.equal result.Message "timeout" "Race must keep waiting for a success after a failure settles first")
 
             testAllRuntimes "RaceEither - first racer wins returns Choice1Of2" (fun runtime ->
                 let fast = FIO.succeed 1

--- a/tests/FIO.Tests/DSL/ExtensionTests.fs
+++ b/tests/FIO.Tests/DSL/ExtensionTests.fs
@@ -1012,6 +1012,54 @@ let extensionTests =
 
                 Expect.equal result (res1, res2) "ZipPar should combine results from parallel execution"
 
+            testAllRuntimes "ZipPar - fails fast when the forked sibling fails (never on left)" (fun runtime ->
+                let error = 42
+                let sentinel = -1
+
+                let effect =
+                    (FIO.never<int, int>().ZipPar(FIO.fail<int, int> error))
+                        .TimeoutFail sentinel (TimeSpan.FromSeconds 2.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(effect).UnsafeError()
+
+                Expect.equal result error "ZipPar should fail fast with the sibling error, not hang until the timeout")
+
+            testAllRuntimes "ZipPar - fails fast when the forked sibling fails (never on right)" (fun runtime ->
+                let error = 42
+                let sentinel = -1
+
+                let effect =
+                    ((FIO.fail<int, int> error).ZipPar(FIO.never<int, int>()))
+                        .TimeoutFail sentinel (TimeSpan.FromSeconds 2.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(effect).UnsafeError()
+
+                Expect.equal result error "ZipPar should fail fast with the sibling error, not hang until the timeout")
+
+            testAllRuntimes "ZipPar - interrupts the long-running sibling on failure (no leak)" (fun runtime ->
+                let error = 7
+                let sentinel = -1
+                let mutable completedNormally = false
+
+                let sibling =
+                    (FIO.sleep (TimeSpan.FromSeconds 10.0) (fun _ -> sentinel))
+                        .FlatMap(fun () -> FIO.attempt (fun () -> completedNormally <- true) (fun _ -> sentinel))
+
+                let effect =
+                    ((FIO.fail<int, int> error).ZipPar sibling)
+                        .TimeoutFail sentinel (TimeSpan.FromSeconds 2.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(effect).UnsafeError()
+
+                Expect.equal result error "ZipPar should surface the sibling failure"
+                Expect.isFalse completedNormally "ZipPar should interrupt the long-running sibling instead of running it to completion")
+
+            testAllRuntimes "ZipPar - both succeed still pairs both values" (fun runtime ->
+                let result =
+                    runtime.Run((FIO.succeed 1).ZipPar(FIO.succeed "two")).UnsafeSuccess()
+
+                Expect.equal result (1, "two") "ZipPar should pair both success values in (this, effect) order")
+
             testPropertyWithConfig fsCheckConfig "ZipParError - both fail returns error tuple"
             <| fun (runtime: FIORuntime) ->
                 let eff1 = FIO.fail "error1"
@@ -1032,7 +1080,7 @@ let extensionTests =
 
                 Expect.equal result value "ZipParError should return success when second succeeds"
 
-            testPropertyWithConfig fsCheckConfig "ZipParError - both succeed returns first"
+            testPropertyWithConfig fsCheckConfig "ZipParError - both succeed returns one of the values"
             <| fun (runtime: FIORuntime, value: int) ->
                 let eff1 = FIO.succeed value
                 let eff2 = FIO.succeed (value + 1)
@@ -1040,7 +1088,49 @@ let extensionTests =
                 let result =
                     runtime.Run(eff1.ZipParError eff2).UnsafeSuccess()
 
-                Expect.equal result value "ZipParError should return first result when both succeed"
+                Expect.isTrue (result = value || result = value + 1) "ZipParError should return one of the concurrent successes"
+
+            testAllRuntimes "ZipParError - succeeds fast when this succeeds and the sibling never terminates" (fun runtime ->
+                let value = 99
+                let sentinel = (-1, -1)
+
+                let effect =
+                    ((FIO.succeed value).ZipParError(FIO.never<int, int>()))
+                        .TimeoutFail sentinel (TimeSpan.FromSeconds 2.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(effect).UnsafeSuccess()
+
+                Expect.equal result value "ZipParError should return the success without waiting on the never-terminating sibling")
+
+            testAllRuntimes "ZipParError - succeeds fast when the sibling succeeds and this never terminates" (fun runtime ->
+                let value = 99
+                let sentinel = (-1, -1)
+
+                let effect =
+                    ((FIO.never<int, int>()).ZipParError(FIO.succeed value))
+                        .TimeoutFail sentinel (TimeSpan.FromSeconds 2.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(effect).UnsafeSuccess()
+
+                Expect.equal result value "ZipParError should return the sibling's success even when this never terminates")
+
+            testAllRuntimes "ZipParError - interrupts the long-running sibling once one side succeeds (no leak)" (fun runtime ->
+                let value = 5
+                let sentinel = (-1, -1)
+                let mutable completedNormally = false
+
+                let sibling =
+                    (FIO.sleep (TimeSpan.FromSeconds 10.0) (fun _ -> 0))
+                        .FlatMap(fun () -> FIO.attempt (fun () -> completedNormally <- true; 0) (fun _ -> 0))
+
+                let effect =
+                    ((FIO.succeed value).ZipParError sibling)
+                        .TimeoutFail sentinel (TimeSpan.FromSeconds 2.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(effect).UnsafeSuccess()
+
+                Expect.equal result value "ZipParError should surface the immediate success"
+                Expect.isFalse completedNormally "ZipParError should interrupt the long-running sibling instead of running it to completion")
 
             testPropertyWithConfig fsCheckConfig "ZipParRight - returns second result from parallel"
             <| fun (runtime: FIORuntime, res1: int, res2: int) ->
@@ -1759,6 +1849,36 @@ let extensionTests =
                 let result = runtime.Run(effect).UnsafeError()
 
                 Expect.equal result.Message error.Message "RaceFirst should propagate error from first completing")
+
+            testAllRuntimes "RaceFirst - an interruption that settles first wins the race" (fun runtime ->
+                let interruptedSide =
+                    (FIO.sleep (TimeSpan.FromMilliseconds 50.0) id)
+                        .FlatMap(fun () -> FIO.interrupt ExplicitInterrupt "settled first")
+                let slowSuccess =
+                    (FIO.sleep (TimeSpan.FromSeconds 10.0) id).FlatMap(fun () -> FIO.succeed 2)
+                let effect = interruptedSide.RaceFirst slowSuccess
+
+                let result = runtime.Run(effect).UnsafeResult()
+
+                match result with
+                | Interrupted _ -> ()
+                | other -> failtest $"RaceFirst should yield the interruption when it settles first, got: %A{other}")
+
+            testAllRuntimes "RaceFirst - loser's Ensuring finalizer runs after losing the race" (fun runtime ->
+                let finalized = Channel<int>()
+                let loser = (FIO.never<int, exn>()).Ensuring((finalized.Write 1).Unit())
+                let winner = (FIO.sleep (TimeSpan.FromMilliseconds 50.0) id).FlatMap(fun () -> FIO.succeed 42)
+
+                let effect =
+                    (winner.RaceFirst loser).FlatMap <| fun value ->
+                        finalized.Read().Map <| fun _ -> value
+
+                let bounded =
+                    effect.TimeoutFail (exn "timeout") (TimeSpan.FromSeconds 5.0) id
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.equal result 42 "RaceFirst should interrupt the loser and run its Ensuring finalizer")
 
             testAllRuntimes "RaceEither - first racer wins returns Choice1Of2" (fun runtime ->
                 let fast = FIO.succeed 1

--- a/tests/FIO.Tests/DSL/FactoryTests.fs
+++ b/tests/FIO.Tests/DSL/FactoryTests.fs
@@ -27,6 +27,9 @@ let private runtimes () =
 let private testAllRuntimes name (f: FIORuntime -> unit) =
     testList name [ for rt in runtimes () -> testCase (rt.GetType().Name) (fun () -> f rt) ]
 
+let private stressTestAllRuntimes name (f: FIORuntime -> unit) =
+    testList name [ for rt in runtimes () -> stressTestCase (rt.GetType().Name) (fun () -> f rt) ]
+
 [<Tests>]
 let factoryTests =
     testList
@@ -2187,4 +2190,87 @@ let factoryTests =
                     [ "fast"; "medium"; "slow" ]
                     result.Message
                     "raceAll should fail with one of the racers' error messages when all racers fail")
+
+            testAllRuntimes "raceAll - interrupted racers retire without breaking the race" (fun runtime ->
+                let interrupted = FIO.interruptNow<int, exn> ()
+                let failing =
+                    (FIO.sleep (TimeSpan.FromMilliseconds 30.0) id).FlatMap(fun () -> FIO.fail (exn "failing"))
+                let succeeding =
+                    (FIO.sleep (TimeSpan.FromMilliseconds 60.0) id).FlatMap(fun () -> FIO.succeed 7)
+                let effect = FIO.raceAll (seq { interrupted; failing; succeeding })
+
+                let bounded =
+                    effect.TimeoutFail (exn "timeout") (TimeSpan.FromSeconds 5.0) id
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.equal result 7 "raceAll should still yield the success after other racers were interrupted or failed")
+
+            testAllRuntimes "raceAll - terminates when the remaining racers fail after one is interrupted" (fun runtime ->
+                let interrupted = FIO.interruptNow<int, exn> ()
+                let fail1 =
+                    (FIO.sleep (TimeSpan.FromMilliseconds 30.0) id).FlatMap(fun () -> FIO.fail (exn "first"))
+                let fail2 =
+                    (FIO.sleep (TimeSpan.FromMilliseconds 60.0) id).FlatMap(fun () -> FIO.fail (exn "last"))
+                let effect = FIO.raceAll (seq { interrupted; fail1; fail2 })
+
+                let bounded =
+                    effect.TimeoutFail (exn "timeout") (TimeSpan.FromSeconds 5.0) id
+
+                let result = runtime.Run(bounded).UnsafeError()
+
+                Expect.contains
+                    [ "first"; "last" ]
+                    result.Message
+                    "raceAll must terminate with a racer error, not hang, when an interrupted racer leaves the race")
+
+            testAllRuntimes "raceAll - every racer interrupted yields Interrupted" (fun runtime ->
+                let effect =
+                    FIO.raceAll (seq {
+                        FIO.interruptNow<int, exn> ()
+                        (FIO.sleep (TimeSpan.FromMilliseconds 30.0) id).FlatMap(fun () -> FIO.interruptNow<int, exn> ())
+                    })
+
+                let bounded =
+                    effect.TimeoutFail (exn "timeout") (TimeSpan.FromSeconds 5.0) id
+
+                let result = runtime.Run(bounded).UnsafeResult()
+
+                match result with
+                | Interrupted _ -> ()
+                | other -> failtest $"raceAll should propagate interruption when every racer is interrupted, got: %A{other}")
+
+            testAllRuntimes "raceAll - a stuck racer does not block a later success" (fun runtime ->
+                let stuck = FIO.never<int, exn> ()
+                let succeeding =
+                    (FIO.sleep (TimeSpan.FromMilliseconds 50.0) id).FlatMap(fun () -> FIO.succeed 3)
+                let effect = FIO.raceAll (seq { stuck; succeeding })
+
+                let bounded =
+                    effect.TimeoutFail (exn "timeout") (TimeSpan.FromSeconds 5.0) id
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.equal result 3 "raceAll should yield the success and interrupt the stuck racer")
+
+            stressTestAllRuntimes "raceAll - stress: repeated re-parks over surviving racers" (fun runtime ->
+                let iterations = 500
+
+                let rec loop i : FIO<unit, exn> =
+                    if i = 0 then
+                        FIO.unit ()
+                    else
+                        let round =
+                            FIO.raceAll (seq {
+                                FIO.fail (exn "retired")
+                                FIO.interruptNow<int, exn> ()
+                                (FIO.sleep (TimeSpan.FromMilliseconds 1.0) id).FlatMap(fun () -> FIO.succeed i)
+                            })
+                        round.FlatMap <| fun value ->
+                            if value = i then loop (i - 1) else FIO.fail (exn $"wrong winner in round {i}")
+
+                let bounded =
+                    (loop iterations).TimeoutFail (exn "timeout") (TimeSpan.FromSeconds 60.0) id
+
+                Expect.equal (runtime.Run(bounded).UnsafeSuccess()) () "every raceAll round should settle on the surviving success")
         ]

--- a/tests/FIO.Tests/DSL/FactoryTests.fs
+++ b/tests/FIO.Tests/DSL/FactoryTests.fs
@@ -1032,6 +1032,21 @@ let factoryTests =
                     Expect.equal error "boom" $"forEachPar on {runtime.GetType().Name} should propagate the failure"
                     Expect.isLessThan peerCompleted failureItems $"forEachPar on {runtime.GetType().Name} should interrupt at least one peer"
 
+            testCase "forEachPar - fails fast even when an earlier peer never terminates"
+            <| fun () ->
+                for runtime in runtimes () do
+                    let sentinel = -1
+
+                    let effect =
+                        (FIO.forEachPar [ 0; 1 ] (fun i ->
+                            if i = 0 then FIO.never<int, int>() else FIO.fail 99))
+                            .TimeoutFail sentinel (TimeSpan.FromSeconds 2.0) (fun _ -> sentinel)
+
+                    let error =
+                        runtime.Run(effect).UnsafeError()
+
+                    Expect.equal error 99 $"forEachPar on {runtime.GetType().Name} should observe the late failure without hanging on the never-terminating earlier peer"
+
             testPropertyWithConfig fsCheckConfig "forEachParDiscard - applies f to each input without collecting"
             <| fun (runtime: FIORuntime, xs: int list) ->
                 let mutable sum = 0

--- a/tests/FIO.Tests/DSL/FiberTests.fs
+++ b/tests/FIO.Tests/DSL/FiberTests.fs
@@ -700,12 +700,16 @@ let fiberTests =
 
                         fiber.Task() |> Async.AwaitTask |> Async.RunSynchronously |> ignore
 
-                        fiber.Context.SetOnTerminal(fun () -> secondCount.Value <- secondCount.Value + 1)
+                        let deadline = DateTime.UtcNow.AddSeconds 5.0
+                        while firstCount.Value = 0 && DateTime.UtcNow < deadline do
+                            Threading.Thread.Sleep 1
 
                         Expect.equal
                             firstCount.Value
                             1
                             "Pre-terminal SetOnTerminal callback should fire exactly once on completion"
+
+                        fiber.Context.SetOnTerminal(fun () -> secondCount.Value <- secondCount.Value + 1)
 
                         Expect.equal
                             secondCount.Value

--- a/tests/FIO.Tests/DSL/JoinAllFailFastTests.fs
+++ b/tests/FIO.Tests/DSL/JoinAllFailFastTests.fs
@@ -1,0 +1,190 @@
+module FIO.Tests.JoinAllFailFastTests
+
+open FIO.Tests.Utilities.FsCheckProperties
+
+open FIO.DSL
+open FIO.Runtime
+open FIO.Runtime.Direct
+open FIO.Runtime.Polling
+open FIO.Runtime.Signaling
+open FIO.Runtime.WorkStealing
+
+open Expecto
+
+open System
+
+let private runtimes () =
+    [
+        new DirectRuntime() :> FIORuntime
+        new PollingRuntime() :> FIORuntime
+        new SignalingRuntime() :> FIORuntime
+        new WorkStealingRuntime() :> FIORuntime
+    ]
+
+let private testAllRuntimes name (func: FIORuntime -> unit) =
+    testList name
+        [ for rt in runtimes () ->
+            testCase (rt.GetType().Name) (fun () -> func rt) ]
+
+let private stressTestAllRuntimes name (func: FIORuntime -> unit) =
+    testList name
+        [ for rt in runtimes () ->
+            stressTestCase (rt.GetType().Name) (fun () -> func rt) ]
+
+[<Tests>]
+let joinAllFailFastTests =
+    testList
+        "JoinAllFailFast Primitive"
+        [
+            testAllRuntimes "joinAllFailFast - fast path returns the lowest index when several failures are already terminal" (fun runtime ->
+                let effect =
+                    (FIO.succeed 1).Fork().FlatMap <| fun okFiber ->
+                        (FIO.fail<int, int> 7).Fork().FlatMap <| fun failed1 ->
+                            (FIO.fail<int, int> 8).Fork().FlatMap <| fun failed2 ->
+                                okFiber.Join().FlatMap <| fun _ ->
+                                    failed1.Await().FlatMap <| fun _ ->
+                                        failed2.Await().FlatMap <| fun _ ->
+                                            FIO.joinAllFailFast [| okFiber.Context; failed1.Context; failed2.Context |]
+
+                let result = runtime.Run(effect).UnsafeSuccess()
+
+                Expect.equal result (ValueSome 1) "joinAllFailFast should return the lowest failed index among terminal fibers")
+
+            testAllRuntimes "joinAllFailFast - all successes settle with ValueNone and results are readable" (fun runtime ->
+                let sentinel = -1
+
+                let effect =
+                    ((FIO.sleep (TimeSpan.FromMilliseconds 50.0) (fun _ -> sentinel)).FlatMap(fun () -> FIO.succeed 1)).Fork().FlatMap <| fun fiber1 ->
+                        (FIO.succeed 2).Fork().FlatMap <| fun fiber2 ->
+                            ((FIO.sleep (TimeSpan.FromMilliseconds 20.0) (fun _ -> sentinel)).FlatMap(fun () -> FIO.succeed 3)).Fork().FlatMap <| fun fiber3 ->
+                                (FIO.joinAllFailFast [| fiber1.Context; fiber2.Context; fiber3.Context |]).FlatMap <| fun outcome ->
+                                    fiber1.Join().FlatMap <| fun value1 ->
+                                        fiber2.Join().FlatMap <| fun value2 ->
+                                            fiber3.Join().Map <| fun value3 ->
+                                                outcome, value1 + value2 + value3
+
+                let bounded =
+                    effect.TimeoutFail sentinel (TimeSpan.FromSeconds 5.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.equal result (ValueNone, 6) "joinAllFailFast should settle with ValueNone once every fiber has succeeded")
+
+            testAllRuntimes "joinAllFailFast - fails fast when a later fiber fails behind a never-terminating peer" (fun runtime ->
+                let sentinel = -1
+
+                let effect =
+                    (FIO.never<int, int>()).Fork().FlatMap <| fun neverFiber ->
+                        ((FIO.sleep (TimeSpan.FromMilliseconds 50.0) (fun _ -> 0)).FlatMap(fun () -> FIO.fail<int, int> 99)).Fork().FlatMap <| fun failingFiber ->
+                            (FIO.joinAllFailFast [| neverFiber.Context; failingFiber.Context |]).FlatMap <| fun outcome ->
+                                neverFiber.InterruptNow().Ignore().As outcome
+
+                let bounded =
+                    effect.TimeoutFail sentinel (TimeSpan.FromSeconds 5.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.equal result (ValueSome 1) "joinAllFailFast should observe the late failure without hanging on the stuck peer")
+
+            testAllRuntimes "joinAllFailFast - an interrupted fiber counts as a non-success" (fun runtime ->
+                let sentinel = -1
+
+                let effect =
+                    (FIO.never<int, int>()).Fork().FlatMap <| fun interruptedFiber ->
+                        (FIO.never<int, int>()).Fork().FlatMap <| fun neverFiber ->
+                            (interruptedFiber.InterruptNow().Ignore()).FlatMap <| fun () ->
+                                (FIO.joinAllFailFast [| interruptedFiber.Context; neverFiber.Context |]).FlatMap <| fun outcome ->
+                                    neverFiber.InterruptNow().Ignore().As outcome
+
+                let bounded =
+                    effect.TimeoutFail sentinel (TimeSpan.FromSeconds 5.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.equal result (ValueSome 0) "joinAllFailFast should treat an interrupted fiber as settling non-successfully")
+
+            testAllRuntimes "joinAllFailFast - parent interruption while parked yields Interrupted without hanging" (fun runtime ->
+                let sentinel = -1
+
+                let parkedJoin =
+                    (FIO.never<unit, int>()).Fork().FlatMap <| fun never1 ->
+                        (FIO.never<unit, int>()).Fork().FlatMap <| fun never2 ->
+                            FIO.joinAllFailFast [| never1.Context; never2.Context |]
+
+                let effect =
+                    parkedJoin.Fork().FlatMap <| fun fiber ->
+                        (FIO.sleep (TimeSpan.FromMilliseconds 100.0) (fun _ -> sentinel)).FlatMap <| fun () ->
+                            fiber.InterruptAwaitNow().FlatMap <| fun result ->
+                                match result with
+                                | Interrupted _ -> FIO.succeed true
+                                | _ -> FIO.succeed false
+
+                let bounded =
+                    effect.TimeoutFail sentinel (TimeSpan.FromSeconds 5.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.isTrue result "Interrupting the parent should tear down a parked joinAllFailFast as Interrupted")
+
+            testAllRuntimes "joinAllFailFast - empty array settles immediately with ValueNone" (fun runtime ->
+                let result = runtime.Run(FIO.joinAllFailFast<int> [||]).UnsafeSuccess()
+
+                Expect.equal result ValueNone "joinAllFailFast on an empty array should succeed immediately with ValueNone")
+
+            testAllRuntimes "joinAllFailFast - single failing fiber settles with ValueSome 0" (fun runtime ->
+                let sentinel = -1
+
+                let effect =
+                    ((FIO.sleep (TimeSpan.FromMilliseconds 50.0) (fun _ -> 0)).FlatMap(fun () -> FIO.fail<int, int> 5)).Fork().FlatMap <| fun fiber ->
+                        FIO.joinAllFailFast [| fiber.Context |]
+
+                let bounded =
+                    effect.TimeoutFail sentinel (TimeSpan.FromSeconds 5.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.equal result (ValueSome 0) "joinAllFailFast on a single failing fiber should settle with its index")
+
+            stressTestAllRuntimes "joinAllFailFast - stress: park races completion without lost wakeups" (fun runtime ->
+                let sentinel = -1
+                let iterations = 1000
+
+                let rec loop i : FIO<unit, int> =
+                    if i = 0 then
+                        FIO.unit ()
+                    else
+                        (FIO.succeed 1).Fork().FlatMap <| fun fiber1 ->
+                            (FIO.succeed 2).Fork().FlatMap <| fun fiber2 ->
+                                (FIO.succeed 3).Fork().FlatMap <| fun fiber3 ->
+                                    (FIO.joinAllFailFast [| fiber1.Context; fiber2.Context; fiber3.Context |]).FlatMap <| fun outcome ->
+                                        match outcome with
+                                        | ValueNone -> loop (i - 1)
+                                        | ValueSome _ -> FIO.fail i
+
+                let bounded =
+                    (loop iterations).TimeoutFail sentinel (TimeSpan.FromSeconds 60.0) (fun _ -> sentinel)
+
+                Expect.equal (runtime.Run(bounded).UnsafeSuccess()) () "every joinAllFailFast in the stress loop should settle with ValueNone")
+
+            testAllRuntimes "joinAllFailFast - settles across a large fan-out" (fun runtime ->
+                let sentinel = -1
+                let count = 10000
+
+                let rec forkAll i (forked: Fiber<int, int> list) =
+                    if i >= count then
+                        FIO.succeed (List.rev forked |> List.toArray)
+                    else
+                        (FIO.succeed i).Fork().FlatMap <| fun fiber ->
+                            forkAll (i + 1) (fiber :: forked)
+
+                let effect =
+                    (forkAll 0 []).FlatMap <| fun fibers ->
+                        FIO.joinAllFailFast (fibers |> Array.map (fun fiber -> fiber.Context))
+
+                let bounded =
+                    effect.TimeoutFail sentinel (TimeSpan.FromSeconds 10.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.equal result ValueNone "joinAllFailFast should settle with ValueNone across a 10k-fiber fan-out")
+        ]

--- a/tests/FIO.Tests/DSL/JoinFirstTests.fs
+++ b/tests/FIO.Tests/DSL/JoinFirstTests.fs
@@ -1,0 +1,150 @@
+module FIO.Tests.JoinFirstTests
+
+open FIO.Tests.Utilities.FsCheckProperties
+
+open FIO.DSL
+open FIO.Runtime
+open FIO.Runtime.Direct
+open FIO.Runtime.Polling
+open FIO.Runtime.Signaling
+open FIO.Runtime.WorkStealing
+
+open Expecto
+
+open System
+
+let private runtimes () =
+    [
+        new DirectRuntime() :> FIORuntime
+        new PollingRuntime() :> FIORuntime
+        new SignalingRuntime() :> FIORuntime
+        new WorkStealingRuntime() :> FIORuntime
+    ]
+
+let private testAllRuntimes name (func: FIORuntime -> unit) =
+    testList name
+        [ for rt in runtimes () ->
+            testCase (rt.GetType().Name) (fun () -> func rt) ]
+
+let private stressTestAllRuntimes name (func: FIORuntime -> unit) =
+    testList name
+        [ for rt in runtimes () ->
+            stressTestCase (rt.GetType().Name) (fun () -> func rt) ]
+
+[<Tests>]
+let joinFirstTests =
+    testList
+        "JoinFirst Primitive"
+        [
+            testAllRuntimes "joinFirst - fast path returns the lowest index when several fibers are already terminal" (fun runtime ->
+                let effect =
+                    (FIO.succeed 1).Fork().FlatMap <| fun fiber1 ->
+                        (FIO.succeed 2).Fork().FlatMap <| fun fiber2 ->
+                            fiber1.Join().FlatMap <| fun _ ->
+                                fiber2.Join().FlatMap <| fun _ ->
+                                    FIO.joinFirst [fiber1.Context; fiber2.Context]
+
+                let result = runtime.Run(effect).UnsafeSuccess()
+
+                Expect.equal result 0 "joinFirst should return the lowest terminal index when several fibers have settled")
+
+            testAllRuntimes "joinFirst - blocking path returns the first fiber to settle" (fun runtime ->
+                let sentinel = -1
+
+                let effect =
+                    (FIO.sleep (TimeSpan.FromSeconds 10.0) (fun _ -> sentinel)).Fork().FlatMap <| fun slowFiber ->
+                        (FIO.sleep (TimeSpan.FromMilliseconds 50.0) (fun _ -> sentinel)).Fork().FlatMap <| fun fastFiber ->
+                            (FIO.joinFirst [slowFiber.Context; fastFiber.Context]).FlatMap <| fun index ->
+                                slowFiber.InterruptNow().Ignore().As index
+
+                let bounded =
+                    effect.TimeoutFail sentinel (TimeSpan.FromSeconds 5.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.equal result 1 "joinFirst should resume with the index of the first fiber to settle")
+
+            testAllRuntimes "joinFirst - a failed fiber counts as settled" (fun runtime ->
+                let sentinel = -1
+
+                let effect =
+                    (FIO.never<unit, int>()).Fork().FlatMap <| fun neverFiber ->
+                        (FIO.fail<unit, int> 7).Fork().FlatMap <| fun failedFiber ->
+                            (FIO.joinFirst [neverFiber.Context; failedFiber.Context]).FlatMap <| fun index ->
+                                neverFiber.InterruptNow().Ignore().As index
+
+                let bounded =
+                    effect.TimeoutFail sentinel (TimeSpan.FromSeconds 5.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.equal result 1 "joinFirst should treat failure as settling, not only success")
+
+            testAllRuntimes "joinFirst - parent interruption while parked yields Interrupted without hanging" (fun runtime ->
+                let sentinel = -1
+
+                let parkedJoin =
+                    (FIO.never<unit, int>()).Fork().FlatMap <| fun never1 ->
+                        (FIO.never<unit, int>()).Fork().FlatMap <| fun never2 ->
+                            FIO.joinFirst [never1.Context; never2.Context]
+
+                let effect =
+                    parkedJoin.Fork().FlatMap <| fun fiber ->
+                        (FIO.sleep (TimeSpan.FromMilliseconds 100.0) (fun _ -> sentinel)).FlatMap <| fun () ->
+                            fiber.InterruptAwaitNow().FlatMap <| fun result ->
+                                match result with
+                                | Interrupted _ -> FIO.succeed true
+                                | _ -> FIO.succeed false
+
+                let bounded =
+                    effect.TimeoutFail sentinel (TimeSpan.FromSeconds 5.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.isTrue result "Interrupting the parent should tear down a parked joinFirst as Interrupted")
+
+            testAllRuntimes "joinFirst - single-element list settles with index 0" (fun runtime ->
+                let sentinel = -1
+
+                let effect =
+                    ((FIO.sleep (TimeSpan.FromMilliseconds 50.0) (fun _ -> sentinel))
+                        .FlatMap(fun () -> FIO.succeed 9)).Fork().FlatMap <| fun fiber ->
+                            (FIO.joinFirst [fiber.Context]).FlatMap <| fun index ->
+                                fiber.Join().Map <| fun value -> index, value
+
+                let bounded =
+                    effect.TimeoutFail sentinel (TimeSpan.FromSeconds 5.0) (fun _ -> sentinel)
+
+                let result = runtime.Run(bounded).UnsafeSuccess()
+
+                Expect.equal result (0, 9) "joinFirst on a single fiber should settle with index 0 once it completes")
+
+            stressTestAllRuntimes "joinFirst - stress: park races completion without lost wakeups" (fun runtime ->
+                let sentinel = -1
+                let iterations = 2000
+
+                let rec loop i : FIO<unit, int> =
+                    if i = 0 then
+                        FIO.unit ()
+                    else
+                        (FIO.succeed i).Fork().FlatMap <| fun quickFiber ->
+                            (FIO.never<int, int>()).Fork().FlatMap <| fun neverFiber ->
+                                (FIO.joinFirst [neverFiber.Context; quickFiber.Context]).FlatMap <| fun index ->
+                                    neverFiber.InterruptNow().Ignore().FlatMap <| fun () ->
+                                        if index = 1 then loop (i - 1) else FIO.fail i
+
+                let bounded =
+                    (loop iterations).TimeoutFail sentinel (TimeSpan.FromSeconds 60.0) (fun _ -> sentinel)
+
+                Expect.equal (runtime.Run(bounded).UnsafeSuccess()) () "every joinFirst in the stress loop should settle on the completed fiber")
+
+            testAllRuntimes "joinFirst - empty list interrupts with InvalidArgument" (fun runtime ->
+                let result = runtime.Run(FIO.joinFirst<int> []).UnsafeResult()
+
+                match result with
+                | Interrupted ex ->
+                    match ex.cause with
+                    | InvalidArgument _ -> ()
+                    | cause -> failtest $"joinFirst on an empty list should interrupt with InvalidArgument, got cause: %A{cause}"
+                | other -> failtest $"joinFirst on an empty list should interrupt with InvalidArgument, got: %A{other}")
+        ]

--- a/tests/FIO.Tests/FIO.Tests.fsproj
+++ b/tests/FIO.Tests/FIO.Tests.fsproj
@@ -16,6 +16,8 @@
         <Compile Include="DSL/ChannelTests.fs" />
         <Compile Include="DSL/ExtensionTests.fs" />
         <Compile Include="DSL/FactoryTests.fs" />
+        <Compile Include="DSL/JoinFirstTests.fs" />
+        <Compile Include="DSL/JoinAllFailFastTests.fs" />
         <Compile Include="DSL/FiberTests.fs" />
         <Compile Include="DSL/CancellationTokenTests.fs" />
         <Compile Include="DSL/FIOTests.fs" />


### PR DESCRIPTION
This pull request adds a new benchmark, **ZipRace**, to the FIO benchmark suite to specifically measure and regression-guard the performance and correctness of parallel combinators (`ZipPar`, `RaceFirst`) in the FIO effect system. It updates the documentation, project files, and CI to include this new benchmark, and clarifies the fail-fast semantics and implementation details of the parallel combinators in both user and developer docs.

**Benchmarking and CI enhancements:**

* Added the `ZipRaceBenchmark` to the benchmark suite, which stresses the per-invocation cost of the `ZipPar` and `RaceFirst` combinators over trivial effects, serving as a microbenchmark and a CI hang canary for the parallel combinator runtime primitives. (`benchmarks/FIO.Benchmarks/Benchmarks/ZipRaceBenchmark.fs`, `benchmarks/FIO.Benchmarks/Effects/ZipRace.fs`, `benchmarks/FIO.Benchmarks/FIO.Benchmarks.fsproj`, `benchmarks/FIO.Benchmarks/Program.fs`, [[1]](diffhunk://#diff-907d109fb8d15eeda3094e1a3ec42c587be375f92c7536a64af102262074f28fR1-R51) [[2]](diffhunk://#diff-fecb4949a3391f552b2c7378e6ccf607a77de875ef4953bbcc6b2ac625408a94R1-R11) [[3]](diffhunk://#diff-0c9a4e3d5b170f914c20339d78d19c5c6f0c2edd2e701c79c1240f7a6892d125R21) [[4]](diffhunk://#diff-0c9a4e3d5b170f914c20339d78d19c5c6f0c2edd2e701c79c1240f7a6892d125R33) [[5]](diffhunk://#diff-8287afce37c81c9ea96b33aa254e674a6c0629a1dacfa73582737995772fd780R72)
* Updated the workflow to support a new environment variable `FIO_BENCH_ZIPRACE_ROUNDS` for parameterizing `ZipRace` rounds. (`.github/workflows/benchmark.yml`, [.github/workflows/benchmark.ymlR58](diffhunk://#diff-aacbd0338bcf598920c120b69adaba2672acc7ea314cfca0f792bebe5fe2acd0R58))

**Documentation and usage updates:**

* Updated user and developer documentation (`README.md`, `benchmarks/FIO.Benchmarks/README.md`, `CLAUDE.md`, `.github/copilot-instructions.md`) to describe the new `ZipRace` benchmark, its purpose, and parameters, and to clarify that the parallel combinators are fail-fast and interrupt losers automatically. [[1]](diffhunk://#diff-6ceb68926ad17fe9d537352c873a846a683ef59b7b8e65323ef99f68668d05abR20-R28) [[2]](diffhunk://#diff-6ceb68926ad17fe9d537352c873a846a683ef59b7b8e65323ef99f68668d05abL43-R52) [[3]](diffhunk://#diff-6ceb68926ad17fe9d537352c873a846a683ef59b7b8e65323ef99f68668d05abR124) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R46) [[5]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L207-R218) [[6]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R244) [[7]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R101-R102) [[8]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L65-R68) [[9]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L77-R78) [[10]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R40) [[11]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L33-R33) [[12]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L60-R60) [[13]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R157)

**Developer and architecture notes:**

* Clarified in developer docs that the parallel combinators (`ZipPar`/`Race` family, `forEachPar`) are fail-fast, settling on the first relevant completion and interrupting other fibers, and documented the new internal primitives `JoinFirst` and `JoinAllFailFast` that underpin these semantics. (`.github/copilot-instructions.md`, [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L33-R33) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L60-R60) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R157) [[4]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R181)
* Updated module and type listings to include new primitives and their implementation details. (`CLAUDE.md`, [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L65-R68) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L77-R78) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R101-R102)

These changes collectively improve the test coverage and correctness guarantees for FIO's parallel combinators, making it easier to detect regressions and clarify their semantics for both users and contributors.<!-- Thanks for contributing to FIO! Please fill out the sections below. -->

## Summary

<!-- What does this PR do, and why? -->

## Related issues

<!-- e.g. Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / internal change (no behavior change)
- [ ] Documentation
- [ ] Build / CI / tooling

## Checklist

- [ ] `dotnet build` succeeds with no warnings (`WarningsAsErrors=true`)
- [ ] `dotnet test` passes
- [ ] Tests added/updated for behavior changes
- [ ] Examples and docs updated where relevant
- [ ] Package versions (if changed) go through `Directory.Packages.props`

## Notes for reviewers

<!-- Anything that needs special attention, trade-offs, or follow-ups. -->
